### PR TITLE
add popup for manual tests - Fixes #4

### DIFF
--- a/sr_gui_self_test/manifest.xml
+++ b/sr_gui_self_test/manifest.xml
@@ -12,6 +12,7 @@
   <depend package="rqt_gui"/>
   <depend package="rqt_gui_py"/>
   <depend package="diagnostic_msgs"/>
+  <depend package="sr_robot_msgs"/>
 
   <export>
     <rqt_gui plugin="${prefix}/sr_self_test_plugin.xml"/>

--- a/sr_gui_self_test/src/sr_gui_self_test/self_test.py
+++ b/sr_gui_self_test/src/sr_gui_self_test/self_test.py
@@ -41,7 +41,7 @@ from python_qt_binding import loadUi
 from sr_robot_msgs.srv import ManualSelfTest, ManualSelfTestResponse
 from diagnostic_msgs.srv import SelfTest
 
-from QtGui import QWidget, QTreeWidgetItem, QColor, QPixmap, QMessageBox, QInputDialog
+from QtGui import QWidget, QTreeWidgetItem, QColor, QPixmap, QMessageBox, QInputDialog, QDialog
 from QtCore import QThread, SIGNAL, QPoint
 from QtCore import Qt
 
@@ -278,9 +278,15 @@ class SrGuiSelfTest(Plugin):
     def on_manual_test_(self, point):
         thread = self.test_threads[point.x()]
 
-        text, ok = QInputDialog.getText(self._widget, "Manual Test", thread.manual_test_req_.message)
+        input_dialog = QInputDialog(self._widget)
+        input_dialog.setOkButtonText("OK - Test successful.")
+        input_dialog.setCancelButtonText("NO - Test failed (please enter a comment to say why the test fail above).")
+        input_dialog.setLabelText(thread.manual_test_req_.message)
+        input_dialog.setWindowTitle( thread.node_name + " - Manual Test")
 
-        thread.manual_test_res_ = ManualSelfTestResponse(ok, text)
+        ok = (QDialog.Accepted == input_dialog.exec_())
+
+        thread.manual_test_res_ = ManualSelfTestResponse(ok, input_dialog.textValue())
 
     def display_plots_(self, display_node):
         """

--- a/sr_gui_self_test/src/sr_gui_self_test/self_test.py
+++ b/sr_gui_self_test/src/sr_gui_self_test/self_test.py
@@ -86,10 +86,6 @@ class AsyncService(QThread):
         """
         Calls the node/self_test service and emits a signal once it's finished running.
         """
-        import time
-        for i in range(0,100):
-            time.sleep(0.1)
-
         self_test_srv = rospy.ServiceProxy(self.service_name, SelfTest)
         try:
             self.resp = self_test_srv()


### PR DESCRIPTION
A QInputDialog pops up when a manual test needs to be run. It displays the message sent by the self test. The user can either say that the test passed or failed (and provide a reason why)

![Selection_026](https://f.cloud.github.com/assets/557182/386409/c166a606-a6a5-11e2-9256-1f94716d6d1c.png)
