### PR TITLE
Handle multiple hands in controller tuner GUI

### DIFF
--- a/sr_gui_controller_tuner/src/sr_gui_controller_tuner/controller_tuner.py
+++ b/sr_gui_controller_tuner/src/sr_gui_controller_tuner/controller_tuner.py
@@ -36,8 +36,9 @@ from sensor_msgs.msg import JointState
 
 from sr_gui_controller_tuner.sr_controller_tuner import SrControllerTunerApp
 
+
 class PlotThread(QThread):
-    def __init__(self, parent = None, joint_name = "FFJ0", controller_type = "Motor Force"):
+    def __init__(self, parent=None, joint_name="FFJ0", controller_type="Motor Force"):
         QThread.__init__(self, parent)
         self.joint_name_ = joint_name
         self.is_joint_0_ = False
@@ -52,7 +53,7 @@ class PlotThread(QThread):
 
         #prepares the title for the plot (can't contain spaces)
         self.plot_title_ = self.joint_name_ + " " + self.controller_type_
-        self.plot_title_ = self.plot_title_.replace(" ", "_").replace("/","_")
+        self.plot_title_ = self.plot_title_.replace(" ", "_").replace("/", "_")
 
         #stores the subprocesses to be able to terminate them on close
         self.subprocess_ = []
@@ -73,29 +74,42 @@ class PlotThread(QThread):
 
                 #wait until we got the joint index in the joint
                 # states message
-                while self.joint_index_in_joint_state_ == None:
+                while self.joint_index_in_joint_state_ is None:
                     time.sleep(0.01)
 
-                rxplot_str += "joint_states/effort["+ str(self.joint_index_in_joint_state_) +"]"
+                rxplot_str += "joint_states/effort[" + str(self.joint_index_in_joint_state_) + "]"
             else:
-                rxplot_str += "joint_0s/joint_states/effort["+ str(self.joint_index_in_joint_state_) +"]"
+                rxplot_str += "joint_0s/joint_states/effort[" + str(self.joint_index_in_joint_state_) + "]"
 
         elif self.controller_type_ == "Position":
-            rxplot_str += "sh_"+self.joint_name_.lower()+"_position_controller/state/set_point,sh_"+self.joint_name_.lower()+"_position_controller/state/process_value sh_" + self.joint_name_.lower()+"_position_controller/state/command"
+            rxplot_str += "sh_" + self.joint_name_.lower() + "_position_controller/state/set_point,sh_" + self.joint_name_.lower() +\
+                          "_position_controller/state/process_value sh_" + self.joint_name_.lower() + "_position_controller/state/command"
         elif self.controller_type_ == "Muscle Position":
-            rxplot_str += "sh_"+self.joint_name_.lower()+"_muscle_position_controller/state/set_point,sh_"+self.joint_name_.lower()+"_muscle_position_controller/state/process_value sh_" + self.joint_name_.lower()+"_muscle_position_controller/state/pseudo_command sh_" + self.joint_name_.lower()+"_muscle_position_controller/state/valve_muscle_0,sh_" + self.joint_name_.lower()+"_muscle_position_controller/state/valve_muscle_1"
+            rxplot_str += "sh_" + self.joint_name_.lower() + "_muscle_position_controller/state/set_point,sh_" + self.joint_name_.lower() +\
+                          "_muscle_position_controller/state/process_value sh_" + self.joint_name_.lower() +\
+                          "_muscle_position_controller/state/pseudo_command sh_" + self.joint_name_.lower() +\
+                          "_muscle_position_controller/state/valve_muscle_0,sh_" + self.joint_name_.lower() +\
+                          "_muscle_position_controller/state/valve_muscle_1"
         elif self.controller_type_ == "Velocity":
-            rxplot_str += "sh_"+self.joint_name_.lower()+"_velocity_controller/state/set_point,sh_"+self.joint_name_.lower()+"_velocity_controller/state/process_value"
+            rxplot_str += "sh_" + self.joint_name_.lower() + "_velocity_controller/state/set_point,sh_" + self.joint_name_.lower() +\
+                          "_velocity_controller/state/process_value"
         elif self.controller_type_ == "Mixed Position/Velocity":
-            rxplot_str += "sh_"+self.joint_name_.lower()+"_mixed_position_velocity_controller/state/set_point,sh_"+self.joint_name_.lower()+"_mixed_position_velocity_controller/state/process_value sh_"+self.joint_name_.lower()+"_mixed_position_velocity_controller/state/process_value_dot,sh_"+self.joint_name_.lower()+"_mixed_position_velocity_controller/state/commanded_velocity sh_"+self.joint_name_.lower()+"_mixed_position_velocity_controller/state/command,sh_"+self.joint_name_.lower()+"_mixed_position_velocity_controller/state/measured_effort,sh_"+self.joint_name_.lower()+"_mixed_position_velocity_controller/state/friction_compensation"
+            rxplot_str += "sh_" + self.joint_name_.lower() + "_mixed_position_velocity_controller/state/set_point,sh_" +\
+                          self.joint_name_.lower() + "_mixed_position_velocity_controller/state/process_value sh_" + self.joint_name_.lower() +\
+                          "_mixed_position_velocity_controller/state/process_value_dot,sh_" + self.joint_name_.lower() +\
+                          "_mixed_position_velocity_controller/state/commanded_velocity sh_" + self.joint_name_.lower() +\
+                          "_mixed_position_velocity_controller/state/command,sh_" + self.joint_name_.lower() +\
+                          "_mixed_position_velocity_controller/state/measured_effort,sh_" + self.joint_name_.lower() +\
+                          "_mixed_position_velocity_controller/state/friction_compensation"
         elif self.controller_type_ == "Effort":
-            rxplot_str += "sh_"+self.joint_name_.lower()+"_effort_controller/state/set_point,sh_"+self.joint_name_.lower()+"_effort_controller/state/process_value"
+            rxplot_str += "sh_" + self.joint_name_.lower() + "_effort_controller/state/set_point,sh_" + self.joint_name_.lower() +\
+                          "_effort_controller/state/process_value"
 
-        self.subprocess_.append( subprocess.Popen(rxplot_str.split()) )
+        self.subprocess_.append(subprocess.Popen(rxplot_str.split()))
 
     def js_callback_(self, msg):
         #get the joint index once, then unregister
-        self.joint_index_in_joint_state_ = msg.name.index( self.joint_name_.upper() )
+        self.joint_index_in_joint_state_ = msg.name.index(self.joint_name_.upper())
         self.subscriber_.unregister()
         self.subscriber_ = None
 
@@ -104,14 +118,15 @@ class PlotThread(QThread):
             #killing the rxplot to close the window
             subprocess.kill()
 
-        if self.subscriber_ != None:
+        if self.subscriber_ is not None:
             self.subscriber_.unregister()
             self.subscriber_ = None
 
         self.wait()
 
+
 class MoveThread(QThread):
-    def __init__(self, parent = None, joint_name = "FFJ0", controller_type = "Motor Force"):
+    def __init__(self, parent=None, joint_name="FFJ0", controller_type="Motor Force"):
         QThread.__init__(self, parent)
         self.joint_name_ = joint_name
         self.controller_type_ = controller_type
@@ -142,14 +157,14 @@ class MoveThread(QThread):
             message_type = "sr"
 
         min_max = self.get_min_max_()
-        ns = rospy.get_namespace()
+        namespace = rospy.get_namespace()
 
-        string = "<launch> <node ns=\"" + ns + "\" pkg=\"sr_movements\" name=\"sr_movements\" type=\"sr_movements\">"
-        string += "<remap from=\"~targets\" to=\""+ controller_name_ +"/command\"/>"
-        string += "<remap from=\"~inputs\" to=\""+ controller_name_ +"/state\"/>"
+        string = "<launch> <node ns=\"" + namespace + "\" pkg=\"sr_movements\" name=\"sr_movements\" type=\"sr_movements\">"
+        string += "<remap from=\"~targets\" to=\"" + controller_name_ + "/command\"/>"
+        string += "<remap from=\"~inputs\" to=\"" + controller_name_ + "/state\"/>"
         string += "<param name=\"image_path\" value=\"$(find sr_movements)/movements/test.png\"/>"
-        string += "<param name=\"min\" value=\""+ str(min_max[0]) +"\"/>"
-        string += "<param name=\"max\" value=\""+ str(min_max[1]) + "\"/>"
+        string += "<param name=\"min\" value=\"" + str(min_max[0]) + "\"/>"
+        string += "<param name=\"max\" value=\"" + str(min_max[1]) + "\"/>"
         string += "<param name=\"publish_rate\" value=\"100\"/>"
         string += "<param name=\"repetition\" value=\"1000\"/>"
         string += "<param name=\"nb_step\" value=\"10000\"/>"
@@ -198,7 +213,8 @@ class MoveThread(QThread):
 
         launch_string = "roslaunch "+filename
 
-        self.subprocess_.append( subprocess.Popen(launch_string.split()) )
+        self.subprocess_.append(subprocess.Popen(launch_string.split()))
+
 
 class SrGuiControllerTuner(Plugin):
     """
@@ -219,14 +235,14 @@ class SrGuiControllerTuner(Plugin):
         loadUi(ui_file, self._widget)
         self._widget.setObjectName('SrControllerTunerUi')
         context.add_widget(self._widget)
-        
+
         #setting the prefixes
         self._prefix = ""
-        
+
         self._widget.select_prefix.addItem("")
         self._widget.select_prefix.addItem("rh/")
         self._widget.select_prefix.addItem("lh/")
-        
+
         self._widget.select_prefix.currentIndexChanged['QString'].connect(self.prefix_selected)
 
         #stores the movements threads to be able to stop them
@@ -240,10 +256,11 @@ class SrGuiControllerTuner(Plugin):
         self.ctrl_widgets = {}
 
         #a library which helps us doing the real work.
-        self.sr_controller_tuner_app_ = SrControllerTunerApp( os.path.join(rospkg.RosPack().get_path('sr_gui_controller_tuner'), 'data', 'controller_settings.xml') )
+        self.sr_controller_tuner_app_ = SrControllerTunerApp(os.path.join(rospkg.RosPack().get_path('sr_gui_controller_tuner'),
+                                                             'data', 'controller_settings.xml'))
 
-        self.sr_controller_tuner_app_.prefix=self._prefix
-        self.sr_controller_tuner_app_.selected_prefix=self._prefix
+        self.sr_controller_tuner_app_.prefix = self._prefix
+        self.sr_controller_tuner_app_.selected_prefix = self._prefix
         #check the prefix once
         self.sr_controller_tuner_app_.check_prefix()
         #refresh the controllers once
@@ -271,15 +288,15 @@ class SrGuiControllerTuner(Plugin):
         move_thread.start()
         self.move_threads.append(move_thread)
 
-    def on_changed_controller_type_(self, index = None):
+    def on_changed_controller_type_(self, index=None):
         """
         When controller type is changed clear the chosen file path and refresh the tree with the controller settings
         """
-        if index == None:
+        if index is None:
             return
         self.reset_file_path()
-        if len(self.controllers_in_dropdown)>0 :
-            self.refresh_controller_tree_( self.controllers_in_dropdown[index] )
+        if len(self.controllers_in_dropdown) > 0:
+            self.refresh_controller_tree_(self.controllers_in_dropdown[index])
 
     def reset_file_path(self):
         """
@@ -309,7 +326,7 @@ class SrGuiControllerTuner(Plugin):
         # '' normally for a right hand  or 'lh' if this is for a left hand)
         # the prefix for config dir must use the "checked" prefix, not the selected one (to handle GUI ns)
         config_subdir = rospy.get_param(self.sr_controller_tuner_app_.prefix+'config_dir', '')
-        print "config_subdir: ",config_subdir
+        print "config_subdir: ", config_subdir
         subpath = "/controls/host/" + config_subdir
         if self.sr_controller_tuner_app_.edit_only_mode:
             filter_files = "*.yaml"
@@ -360,11 +377,11 @@ class SrGuiControllerTuner(Plugin):
         """
         reload the parameters in rosparam, then refresh the tree widget
         """
-        paramlist = rosparam.load_file( self.file_to_save )
-        for params,ns in paramlist:
-            rosparam.upload_params(ns, params)
+        paramlist = rosparam.load_file(self.file_to_save)
+        for params, namespace in paramlist:
+            rosparam.upload_params(namespace, params)
 
-        self.refresh_controller_tree_( self.controllers_in_dropdown[self._widget.dropdown_ctrl.currentIndex()] )
+        self.refresh_controller_tree_(self.controllers_in_dropdown[self._widget.dropdown_ctrl.currentIndex()])
 
     def on_btn_save_selected_clicked_(self):
         """
@@ -372,19 +389,19 @@ class SrGuiControllerTuner(Plugin):
         """
         selected_items = self._widget.tree_ctrl_settings.selectedItems()
 
-        if len( selected_items ) == 0:
+        if len(selected_items) == 0:
             QMessageBox.warning(self._widget.tree_ctrl_settings, "Warning", "No motors selected.")
 
         for it in selected_items:
             if str(it.text(1)) != "":
-                self.save_controller( str(it.text(1)) )
+                self.save_controller(str(it.text(1)))
 
     def on_btn_save_all_clicked_(self):
         """
         Save all controllers
         """
         for motor in self.ctrl_widgets.keys():
-            self.save_controller( motor )
+            self.save_controller(motor)
 
     def on_btn_set_selected_clicked_(self):
         """
@@ -392,19 +409,19 @@ class SrGuiControllerTuner(Plugin):
         """
         selected_items = self._widget.tree_ctrl_settings.selectedItems()
 
-        if len( selected_items ) == 0:
+        if len(selected_items) == 0:
             QMessageBox.warning(self._widget.tree_ctrl_settings, "Warning", "No motors selected.")
 
         for it in selected_items:
             if str(it.text(1)) != "":
-                self.set_controller( str(it.text(1)) )
+                self.set_controller(str(it.text(1)))
 
     def on_btn_set_all_clicked_(self):
         """
         Sets the current values for all controllers using the ros service.
         """
         for motor in self.ctrl_widgets.keys():
-            self.set_controller( motor )
+            self.set_controller(motor)
 
     def on_btn_refresh_ctrl_clicked_(self):
         """
@@ -422,7 +439,7 @@ class SrGuiControllerTuner(Plugin):
 
     def prefix_selected(self, prefix):
         self._prefix = prefix
-        self.sr_controller_tuner_app_.selected_prefix=self._prefix
+        self.sr_controller_tuner_app_.selected_prefix = self._prefix
         self.sr_controller_tuner_app_.check_prefix()
         self.on_btn_refresh_ctrl_clicked_()
 
@@ -434,12 +451,12 @@ class SrGuiControllerTuner(Plugin):
 
         settings = {}
         for item in dict_of_widgets.items():
-            try:            
+            try:
                 settings[item[0]] = item[1].value()
-            except AttributeError, TypeError:
+            except AttributeError:
                 try:
                     settings[item[0]] = 1 if item[1].checkState() == Qt.Checked else 0
-                except AttributeError, TypeError:
+                except AttributeError:
                     pass
         return settings
 
@@ -447,28 +464,27 @@ class SrGuiControllerTuner(Plugin):
         """
         Sets the current values for the given controller using the ros service.
         """
-        settings = self.read_settings( joint_name )
+        settings = self.read_settings(joint_name)
 
         #uses the library to call the service properly
         success = self.sr_controller_tuner_app_.set_controller(joint_name, self.controller_type, settings)
-        if success == False:
+        if success is False:
             if self.controller_type == "Motor Force":
-                QMessageBox.warning(self._widget.tree_ctrl_settings, "Warning", "Failed to set the PID values for joint "+ joint_name +". This won't work for Gazebo controllers as there are no force controllers yet.")
+                QMessageBox.warning(self._widget.tree_ctrl_settings, "Warning", "Failed to set the PID values for joint " + joint_name
+                                    + ". This won't work for Gazebo controllers as there are no force controllers yet.")
             else:
-                QMessageBox.warning(self._widget.tree_ctrl_settings, "Warning", "Failed to set the PID values for joint "+ joint_name +".")
-
+                QMessageBox.warning(self._widget.tree_ctrl_settings, "Warning", "Failed to set the PID values for joint " + joint_name + ".")
 
     def save_controller(self, joint_name):
         """
         Saves the current values for the given controller using the ros service.
         """
-        settings = self.read_settings( joint_name )
+        settings = self.read_settings(joint_name)
 
         #uses the library to call the service properly
         self.sr_controller_tuner_app_.save_controller(joint_name, self.controller_type, settings, self.file_to_save)
 
-
-    def refresh_controller_tree_(self, controller_type = "Motor Force"):
+    def refresh_controller_tree_(self, controller_type="Motor Force"):
         """
         Get the controller settings and their ranges and display them in the tree.
         Buttons and plots will be added unless in edit_only mode.
@@ -487,33 +503,33 @@ class SrGuiControllerTuner(Plugin):
             self._widget.btn_stop_mvts.setEnabled(True)
 
         self.controller_type = controller_type
-        ctrl_settings = self.sr_controller_tuner_app_.get_controller_settings( controller_type )
+        ctrl_settings = self.sr_controller_tuner_app_.get_controller_settings(controller_type)
 
         self._widget.tree_ctrl_settings.clear()
         self._widget.tree_ctrl_settings.setColumnCount(ctrl_settings.nb_columns)
         # clear the ctrl_widgets as the motor name might change also now
-        self.ctrl_widgets={}
+        self.ctrl_widgets = {}
 
         tmp_headers = []
         for header in ctrl_settings.headers:
-            tmp_headers.append( header["name"] )
-        self._widget.tree_ctrl_settings.setHeaderLabels( tmp_headers )
+            tmp_headers.append(header["name"])
+        self._widget.tree_ctrl_settings.setHeaderLabels(tmp_headers)
 
         hand_item = QTreeWidgetItem(ctrl_settings.hand_item)
         self._widget.tree_ctrl_settings.addTopLevelItem(hand_item)
-        for index_finger,finger_settings in enumerate(ctrl_settings.fingers):
-            finger_item = QTreeWidgetItem( hand_item, finger_settings )
+        for index_finger, finger_settings in enumerate(ctrl_settings. fingers):
+            finger_item = QTreeWidgetItem(hand_item, finger_settings)
             self._widget.tree_ctrl_settings.addTopLevelItem(finger_item)
             for motor_settings in ctrl_settings.motors[index_finger]:
                 motor_name = motor_settings[1]
 
-                motor_item = QTreeWidgetItem( finger_item, motor_settings )
+                motor_item = QTreeWidgetItem(finger_item, motor_settings)
                 self._widget.tree_ctrl_settings.addTopLevelItem(motor_item)
 
-                parameter_values = self.sr_controller_tuner_app_.load_parameters( controller_type, motor_name )
+                parameter_values = self.sr_controller_tuner_app_.load_parameters(controller_type, motor_name)
                 if parameter_values != -1:
                     #the parameters have been found
-                    self.ctrl_widgets[ motor_name ] = {}
+                    self.ctrl_widgets[motor_name] = {}
 
                     #buttons for plot/move are not added in edit_only_mode
                     if not self.sr_controller_tuner_app_.edit_only_mode:
@@ -521,21 +537,23 @@ class SrGuiControllerTuner(Plugin):
                         frame_buttons = QFrame()
                         layout_buttons = QHBoxLayout()
                         btn_plot = QPushButton("Plot")
-                        self.ctrl_widgets[ motor_name ]["btn_plot"] = btn_plot
-                        self.ctrl_widgets[ motor_name ]["btn_plot"].clicked.connect(partial(self.on_btn_plot_pressed_, motor_name, self.ctrl_widgets[ motor_name ]["btn_plot"]))
+                        self.ctrl_widgets[motor_name]["btn_plot"] = btn_plot
+                        self.ctrl_widgets[motor_name]["btn_plot"].clicked.connect(partial(self.on_btn_plot_pressed_,
+                                                                                  motor_name, self.ctrl_widgets[motor_name]["btn_plot"]))
                         layout_buttons.addWidget(btn_plot)
 
                         if self.controller_type in ["Position", "Muscle Position", "Mixed Position/Velocity"]:
                             #only adding Move button for position controllers
                             btn_move = QPushButton("Move")
-                            self.ctrl_widgets[ motor_name ]["btn_move"] = btn_move
-                            self.ctrl_widgets[ motor_name ]["btn_move"].clicked.connect(partial(self.on_btn_move_pressed_,motor_name, self.ctrl_widgets[ motor_name ]["btn_move"]))
+                            self.ctrl_widgets[motor_name]["btn_move"] = btn_move
+                            self.ctrl_widgets[motor_name]["btn_move"].clicked.connect(partial(self.on_btn_move_pressed_, motor_name,
+                                                                                      self.ctrl_widgets[motor_name]["btn_move"]))
                             layout_buttons.addWidget(btn_move)
                             frame_buttons.setLayout(layout_buttons)
 
-                        self._widget.tree_ctrl_settings.setItemWidget(  motor_item, 0, frame_buttons )
+                        self._widget.tree_ctrl_settings.setItemWidget(motor_item, 0, frame_buttons)
 
-                    for index_item,item in enumerate(ctrl_settings.headers):
+                    for index_item, item in enumerate(ctrl_settings.headers):
                         if item["type"] == "Bool":
                             check_box = QCheckBox()
 
@@ -544,32 +562,31 @@ class SrGuiControllerTuner(Plugin):
                             check_box.setChecked(param_val)
                             if "sign" in param_name:
                                 check_box.setToolTip("Check if you want a negative sign\n(if the motor is being driven\n the wrong way around).")
-                                
-                            self._widget.tree_ctrl_settings.setItemWidget(  motor_item, index_item, check_box )
 
-                            self.ctrl_widgets[ motor_name ][param_name] = check_box
+                            self._widget.tree_ctrl_settings.setItemWidget(motor_item, index_item, check_box)
 
+                            self.ctrl_widgets[motor_name][param_name] = check_box
 
                         if item["type"] == "Int":
                             spin_box = QSpinBox()
-                            spin_box.setRange(int( item["min"] ), int( item["max"] ))
+                            spin_box.setRange(int(item["min"]), int(item["max"]))
 
                             param_name = item["name"].lower()
-                            spin_box.setValue( int(parameter_values[ param_name ] ) )
-                            self.ctrl_widgets[ motor_name ][param_name] = spin_box
+                            spin_box.setValue(int(parameter_values[param_name]))
+                            self.ctrl_widgets[motor_name][param_name] = spin_box
 
-                            self._widget.tree_ctrl_settings.setItemWidget(  motor_item, index_item, spin_box )
+                            self._widget.tree_ctrl_settings.setItemWidget(motor_item, index_item, spin_box)
 
                         if item["type"] == "Float":
                             spin_box = QDoubleSpinBox()
-                            spin_box.setRange( -65535.0, 65535.0 )
+                            spin_box.setRange(-65535.0, 65535.0)
                             spin_box.setDecimals(3)
 
                             param_name = item["name"].lower()
                             spin_box.setValue(float(parameter_values[param_name]))
-                            self.ctrl_widgets[ motor_name ][param_name] = spin_box
+                            self.ctrl_widgets[motor_name][param_name] = spin_box
 
-                            self._widget.tree_ctrl_settings.setItemWidget(  motor_item, index_item, spin_box )
+                            self._widget.tree_ctrl_settings.setItemWidget(motor_item, index_item, spin_box)
 
                         motor_item.setExpanded(True)
                 else:
@@ -580,12 +597,10 @@ class SrGuiControllerTuner(Plugin):
         for col in range(0, self._widget.tree_ctrl_settings.columnCount()):
             self._widget.tree_ctrl_settings.resizeColumnToContents(col)
 
-
     def on_btn_stop_mvts_clicked_(self):
         for move_thread in self.move_threads:
             move_thread.__del__()
         self.move_threads = []
-
 
     #########
     #Default methods for the rosgui plugins

--- a/sr_gui_controller_tuner/src/sr_gui_controller_tuner/controller_tuner.py
+++ b/sr_gui_controller_tuner/src/sr_gui_controller_tuner/controller_tuner.py
@@ -410,14 +410,11 @@ class SrGuiControllerTuner(Plugin):
 
         settings = {}
         for item in dict_of_widgets.items():
-            if item[0] == "sign":
-                if item[1].checkState() == Qt.Checked:
-                    settings["sign"] = 1
-                else:
-                    settings["sign"] = 0
-            else:
+            try:
+                settings[item[0]] = item[1].value()
+            except AttributeError:
                 try:
-                    settings[item[0]] = item[1].value()
+                    settings[item[0]] = 1 if item[1].checkState() == Qt.Checked else 0
                 except AttributeError:
                     pass
 
@@ -517,13 +514,15 @@ class SrGuiControllerTuner(Plugin):
                         if item["type"] == "Bool":
                             check_box = QCheckBox()
 
-                            if parameter_values["sign"] == 1.0:
-                                check_box.setChecked(True)
-
-                            check_box.setToolTip("Check if you want a negative sign\n(if the motor is being driven\n the wrong way around).")
+                            param_name = item["name"].lower()
+                            param_val = parameter_values[param_name]
+                            check_box.setChecked(param_val)
+                            if "sign" in param_name:
+                                check_box.setToolTip("Check if you want a negative sign\n(if the motor is being driven\n the wrong way around).")
+                                
                             self._widget.tree_ctrl_settings.setItemWidget(  motor_item, index_item, check_box )
 
-                            self.ctrl_widgets[ motor_name ]["sign"] = check_box
+                            self.ctrl_widgets[ motor_name ][param_name] = check_box
 
 
                         if item["type"] == "Int":

--- a/sr_gui_controller_tuner/src/sr_gui_controller_tuner/controller_tuner.py
+++ b/sr_gui_controller_tuner/src/sr_gui_controller_tuner/controller_tuner.py
@@ -51,11 +51,11 @@ class PlotThread(QThread):
 
         self.controller_type_ = controller_type
 
-        #prepares the title for the plot (can't contain spaces)
+        # prepares the title for the plot (can't contain spaces)
         self.plot_title_ = self.joint_name_ + " " + self.controller_type_
         self.plot_title_ = self.plot_title_.replace(" ", "_").replace("/", "_")
 
-        #stores the subprocesses to be able to terminate them on close
+        # stores the subprocesses to be able to terminate them on close
         self.subprocess_ = []
 
     def run(self):
@@ -63,16 +63,16 @@ class PlotThread(QThread):
         Creates an appropriate plot according to controller type
         Also creates a subscription if controller is of Motor Force type
         """
-        #rxplot_str = "rxplot -b 30 -p 30 --title=" + self.plot_title_ + " "
+        # rxplot_str = "rxplot -b 30 -p 30 --title=" + self.plot_title_ + " "
         rxplot_str = "rosrun rqt_plot rqt_plot "
 
         if self.controller_type_ == "Motor Force":
             # the joint 0s are published on a different topic: /joint_0s/joint_states
             if not self.is_joint_0_:
-                #subscribe to joint_states to get the index of the joint in the message
+                # subscribe to joint_states to get the index of the joint in the message
                 self.subscriber_ = rospy.Subscriber("joint_states", JointState, self.js_callback_)
 
-                #wait until we got the joint index in the joint
+                # wait until we got the joint index in the joint
                 # states message
                 while self.joint_index_in_joint_state_ is None:
                     time.sleep(0.01)
@@ -82,40 +82,40 @@ class PlotThread(QThread):
                 rxplot_str += "joint_0s/joint_states/effort[" + str(self.joint_index_in_joint_state_) + "]"
 
         elif self.controller_type_ == "Position":
-            rxplot_str += "sh_" + self.joint_name_.lower() + "_position_controller/state/set_point,sh_" + self.joint_name_.lower() +\
+            rxplot_str += "sh_" + self.joint_name_.lower() + "_position_controller/state/set_point,sh_" + self.joint_name_.lower() + \
                           "_position_controller/state/process_value sh_" + self.joint_name_.lower() + "_position_controller/state/command"
         elif self.controller_type_ == "Muscle Position":
-            rxplot_str += "sh_" + self.joint_name_.lower() + "_muscle_position_controller/state/set_point,sh_" + self.joint_name_.lower() +\
-                          "_muscle_position_controller/state/process_value sh_" + self.joint_name_.lower() +\
-                          "_muscle_position_controller/state/pseudo_command sh_" + self.joint_name_.lower() +\
-                          "_muscle_position_controller/state/valve_muscle_0,sh_" + self.joint_name_.lower() +\
+            rxplot_str += "sh_" + self.joint_name_.lower() + "_muscle_position_controller/state/set_point,sh_" + self.joint_name_.lower() + \
+                          "_muscle_position_controller/state/process_value sh_" + self.joint_name_.lower() + \
+                          "_muscle_position_controller/state/pseudo_command sh_" + self.joint_name_.lower() + \
+                          "_muscle_position_controller/state/valve_muscle_0,sh_" + self.joint_name_.lower() + \
                           "_muscle_position_controller/state/valve_muscle_1"
         elif self.controller_type_ == "Velocity":
-            rxplot_str += "sh_" + self.joint_name_.lower() + "_velocity_controller/state/set_point,sh_" + self.joint_name_.lower() +\
+            rxplot_str += "sh_" + self.joint_name_.lower() + "_velocity_controller/state/set_point,sh_" + self.joint_name_.lower() + \
                           "_velocity_controller/state/process_value"
         elif self.controller_type_ == "Mixed Position/Velocity":
-            rxplot_str += "sh_" + self.joint_name_.lower() + "_mixed_position_velocity_controller/state/set_point,sh_" +\
-                          self.joint_name_.lower() + "_mixed_position_velocity_controller/state/process_value sh_" + self.joint_name_.lower() +\
-                          "_mixed_position_velocity_controller/state/process_value_dot,sh_" + self.joint_name_.lower() +\
-                          "_mixed_position_velocity_controller/state/commanded_velocity sh_" + self.joint_name_.lower() +\
-                          "_mixed_position_velocity_controller/state/command,sh_" + self.joint_name_.lower() +\
-                          "_mixed_position_velocity_controller/state/measured_effort,sh_" + self.joint_name_.lower() +\
+            rxplot_str += "sh_" + self.joint_name_.lower() + "_mixed_position_velocity_controller/state/set_point,sh_" + \
+                          self.joint_name_.lower() + "_mixed_position_velocity_controller/state/process_value sh_" + self.joint_name_.lower() + \
+                          "_mixed_position_velocity_controller/state/process_value_dot,sh_" + self.joint_name_.lower() + \
+                          "_mixed_position_velocity_controller/state/commanded_velocity sh_" + self.joint_name_.lower() + \
+                          "_mixed_position_velocity_controller/state/command,sh_" + self.joint_name_.lower() + \
+                          "_mixed_position_velocity_controller/state/measured_effort,sh_" + self.joint_name_.lower() + \
                           "_mixed_position_velocity_controller/state/friction_compensation"
         elif self.controller_type_ == "Effort":
-            rxplot_str += "sh_" + self.joint_name_.lower() + "_effort_controller/state/set_point,sh_" + self.joint_name_.lower() +\
+            rxplot_str += "sh_" + self.joint_name_.lower() + "_effort_controller/state/set_point,sh_" + self.joint_name_.lower() + \
                           "_effort_controller/state/process_value"
 
         self.subprocess_.append(subprocess.Popen(rxplot_str.split()))
 
     def js_callback_(self, msg):
-        #get the joint index once, then unregister
+        # get the joint index once, then unregister
         self.joint_index_in_joint_state_ = msg.name.index(self.joint_name_.upper())
         self.subscriber_.unregister()
         self.subscriber_ = None
 
     def __del__(self):
         for subprocess in self.subprocess_:
-            #killing the rxplot to close the window
+            # killing the rxplot to close the window
             subprocess.kill()
 
         if self.subscriber_ is not None:
@@ -145,15 +145,15 @@ class MoveThread(QThread):
         """
         Create a launch file dynamically
         """
-        #Not using automatic move for velocity and effort controllers
+        # Not using automatic move for velocity and effort controllers
         controller_name_ = ""
         message_type = "ros"
         if self.controller_type_ == "Position":
-            controller_name_ = "sh_"+self.joint_name_.lower()+"_position_controller"
+            controller_name_ = "sh_" + self.joint_name_.lower() + "_position_controller"
         if self.controller_type_ == "Muscle Position":
-            controller_name_ = "sh_"+self.joint_name_.lower()+"_muscle_position_controller"
+            controller_name_ = "sh_" + self.joint_name_.lower() + "_muscle_position_controller"
         elif self.controller_type_ == "Mixed Position/Velocity":
-            controller_name_ = "sh_"+self.joint_name_.lower()+"_mixed_position_velocity_controller"
+            controller_name_ = "sh_" + self.joint_name_.lower() + "_mixed_position_velocity_controller"
             message_type = "sr"
 
         min_max = self.get_min_max_()
@@ -211,7 +211,7 @@ class MoveThread(QThread):
         """
         filename = self.create_launch_file_()
 
-        launch_string = "roslaunch "+filename
+        launch_string = "roslaunch " + filename
 
         self.subprocess_.append(subprocess.Popen(launch_string.split()))
 
@@ -220,6 +220,7 @@ class SrGuiControllerTuner(Plugin):
     """
     a rosgui plugin for tuning the sr_mechanism_controllers
     """
+
     def __init__(self, context):
         super(SrGuiControllerTuner, self).__init__(context)
         self.setObjectName('SrGuiControllerTuner')
@@ -236,7 +237,7 @@ class SrGuiControllerTuner(Plugin):
         self._widget.setObjectName('SrControllerTunerUi')
         context.add_widget(self._widget)
 
-        #setting the prefixes
+        # setting the prefixes
         self._prefix = ""
 
         self._widget.select_prefix.addItem("")
@@ -245,27 +246,27 @@ class SrGuiControllerTuner(Plugin):
 
         self._widget.select_prefix.currentIndexChanged['QString'].connect(self.prefix_selected)
 
-        #stores the movements threads to be able to stop them
+        # stores the movements threads to be able to stop them
         self.move_threads = []
 
-        #stores the controllers in the same order as the dropdown
+        # stores the controllers in the same order as the dropdown
         self.controllers_in_dropdown = []
 
-        #stores a dictionary of the widgets containing the data for
+        # stores a dictionary of the widgets containing the data for
         # the different controllers.
         self.ctrl_widgets = {}
 
-        #a library which helps us doing the real work.
+        # a library which helps us doing the real work.
         self.sr_controller_tuner_app_ = SrControllerTunerApp(os.path.join(rospkg.RosPack().get_path('sr_gui_controller_tuner'),
-                                                             'data', 'controller_settings.xml'))
+                                                                          'data', 'controller_settings.xml'))
 
         self.sr_controller_tuner_app_.prefix = self._prefix
         self.sr_controller_tuner_app_.selected_prefix = self._prefix
-        #check the prefix once
+        # check the prefix once
         self.sr_controller_tuner_app_.check_prefix()
-        #refresh the controllers once
+        # refresh the controllers once
         self.on_btn_refresh_ctrl_clicked_()
-        #attach the button pressed to its action
+        # attach the button pressed to its action
         self._widget.btn_refresh_ctrl.pressed.connect(self.on_btn_refresh_ctrl_clicked_)
         self._widget.dropdown_ctrl.currentIndexChanged.connect(self.on_changed_controller_type_)
 
@@ -306,7 +307,7 @@ class SrGuiControllerTuner(Plugin):
 
         self._widget.btn_load.setEnabled(False)
 
-        #disable the save buttons (until a new file has
+        # disable the save buttons (until a new file has
         # been chosen by the user)
         self._widget.btn_save_all.setEnabled(False)
         self._widget.btn_save_selected.setEnabled(False)
@@ -322,11 +323,10 @@ class SrGuiControllerTuner(Plugin):
         except:
             rospy.logwarn("couldn't find the sr_ethercat_hand_config package, do you have the sr_config stack installed?")
 
-        #Reading the param that contains the config_dir suffix that we should use for this hand (e.g.
+        # Reading the param that contains the config_dir suffix that we should use for this hand (e.g.
         # '' normally for a right hand  or 'lh' if this is for a left hand)
         # the prefix for config dir must use the "checked" prefix, not the selected one (to handle GUI ns)
-        config_subdir = rospy.get_param(self.sr_controller_tuner_app_.prefix+'config_dir', '')
-        print "config_subdir: ", config_subdir
+        config_subdir = rospy.get_param(self.sr_controller_tuner_app_.prefix + 'config_dir', '')
         subpath = "/controls/host/" + config_subdir
         if self.sr_controller_tuner_app_.edit_only_mode:
             filter_files = "*.yaml"
@@ -340,18 +340,18 @@ class SrGuiControllerTuner(Plugin):
                     filter_files = "*s.yaml"
 
         if self.controller_type == "Motor Force":
-            filter_files = "Config (*motor"+filter_files+")"
+            filter_files = "Config (*motor" + filter_files + ")"
             subpath = "/controls/motors/" + config_subdir
         elif self.controller_type == "Position":
-            filter_files = "Config (*position_controller"+filter_files+")"
+            filter_files = "Config (*position_controller" + filter_files + ")"
         elif self.controller_type == "Muscle Position":
-            filter_files = "Config (*muscle_joint_position_controller"+filter_files+")"
+            filter_files = "Config (*muscle_joint_position_controller" + filter_files + ")"
         elif self.controller_type == "Velocity":
-            filter_files = "Config (*velocity_controller"+filter_files+")"
+            filter_files = "Config (*velocity_controller" + filter_files + ")"
         elif self.controller_type == "Mixed Position/Velocity":
-            filter_files = "Config (*position_velocity"+filter_files+")"
+            filter_files = "Config (*position_velocity" + filter_files + ")"
         elif self.controller_type == "Effort":
-            filter_files = "Config (*effort_controller"+filter_files+")"
+            filter_files = "Config (*effort_controller" + filter_files + ")"
 
         path_to_config += subpath
 
@@ -368,7 +368,7 @@ class SrGuiControllerTuner(Plugin):
 
         self._widget.btn_load.setEnabled(True)
 
-        #enable the save buttons once a file has
+        # enable the save buttons once a file has
         # been chosen
         self._widget.btn_save_all.setEnabled(True)
         self._widget.btn_save_selected.setEnabled(True)
@@ -438,6 +438,10 @@ class SrGuiControllerTuner(Plugin):
         self.refresh_controller_tree_()
 
     def prefix_selected(self, prefix):
+        """
+        Sets the prefix in the controller tuner app and
+        Refreshes the controllers
+        """
         self._prefix = prefix
         self.sr_controller_tuner_app_.selected_prefix = self._prefix
         self.sr_controller_tuner_app_.check_prefix()
@@ -445,7 +449,7 @@ class SrGuiControllerTuner(Plugin):
 
     def read_settings(self, joint_name):
         """
-        retrive settings for joint with given name
+        retrieve settings for joint with given name
         """
         dict_of_widgets = self.ctrl_widgets[joint_name]
 
@@ -466,12 +470,12 @@ class SrGuiControllerTuner(Plugin):
         """
         settings = self.read_settings(joint_name)
 
-        #uses the library to call the service properly
+        # uses the library to call the service properly
         success = self.sr_controller_tuner_app_.set_controller(joint_name, self.controller_type, settings)
         if success is False:
             if self.controller_type == "Motor Force":
-                QMessageBox.warning(self._widget.tree_ctrl_settings, "Warning", "Failed to set the PID values for joint " + joint_name
-                                    + ". This won't work for Gazebo controllers as there are no force controllers yet.")
+                QMessageBox.warning(self._widget.tree_ctrl_settings, "Warning", "Failed to set the PID values for joint " + joint_name +
+                                    ". This won't work for Gazebo controllers as there are no force controllers yet.")
             else:
                 QMessageBox.warning(self._widget.tree_ctrl_settings, "Warning", "Failed to set the PID values for joint " + joint_name + ".")
 
@@ -481,7 +485,7 @@ class SrGuiControllerTuner(Plugin):
         """
         settings = self.read_settings(joint_name)
 
-        #uses the library to call the service properly
+        # uses the library to call the service properly
         self.sr_controller_tuner_app_.save_controller(joint_name, self.controller_type, settings, self.file_to_save)
 
     def refresh_controller_tree_(self, controller_type="Motor Force"):
@@ -517,7 +521,7 @@ class SrGuiControllerTuner(Plugin):
 
         hand_item = QTreeWidgetItem(ctrl_settings.hand_item)
         self._widget.tree_ctrl_settings.addTopLevelItem(hand_item)
-        for index_finger, finger_settings in enumerate(ctrl_settings. fingers):
+        for index_finger, finger_settings in enumerate(ctrl_settings.fingers):
             finger_item = QTreeWidgetItem(hand_item, finger_settings)
             self._widget.tree_ctrl_settings.addTopLevelItem(finger_item)
             for motor_settings in ctrl_settings.motors[index_finger]:
@@ -528,26 +532,26 @@ class SrGuiControllerTuner(Plugin):
 
                 parameter_values = self.sr_controller_tuner_app_.load_parameters(controller_type, motor_name)
                 if parameter_values != -1:
-                    #the parameters have been found
+                    # the parameters have been found
                     self.ctrl_widgets[motor_name] = {}
 
-                    #buttons for plot/move are not added in edit_only_mode
+                    # buttons for plot/move are not added in edit_only_mode
                     if not self.sr_controller_tuner_app_.edit_only_mode:
-                        #add buttons for the automatic procedures (plot / move / ...)
+                        # add buttons for the automatic procedures (plot / move / ...)
                         frame_buttons = QFrame()
                         layout_buttons = QHBoxLayout()
                         btn_plot = QPushButton("Plot")
                         self.ctrl_widgets[motor_name]["btn_plot"] = btn_plot
                         self.ctrl_widgets[motor_name]["btn_plot"].clicked.connect(partial(self.on_btn_plot_pressed_,
-                                                                                  motor_name, self.ctrl_widgets[motor_name]["btn_plot"]))
+                                                                                          motor_name, self.ctrl_widgets[motor_name]["btn_plot"]))
                         layout_buttons.addWidget(btn_plot)
 
                         if self.controller_type in ["Position", "Muscle Position", "Mixed Position/Velocity"]:
-                            #only adding Move button for position controllers
+                            # only adding Move button for position controllers
                             btn_move = QPushButton("Move")
                             self.ctrl_widgets[motor_name]["btn_move"] = btn_move
                             self.ctrl_widgets[motor_name]["btn_move"].clicked.connect(partial(self.on_btn_move_pressed_, motor_name,
-                                                                                      self.ctrl_widgets[motor_name]["btn_move"]))
+                                                                                              self.ctrl_widgets[motor_name]["btn_move"]))
                             layout_buttons.addWidget(btn_move)
                             frame_buttons.setLayout(layout_buttons)
 
@@ -560,7 +564,7 @@ class SrGuiControllerTuner(Plugin):
                             param_name = item["name"].lower()
                             param_val = parameter_values[param_name]
                             check_box.setChecked(param_val)
-                            if "sign" in param_name:
+                            if param_name == "sign":
                                 check_box.setToolTip("Check if you want a negative sign\n(if the motor is being driven\n the wrong way around).")
 
                             self._widget.tree_ctrl_settings.setItemWidget(motor_item, index_item, check_box)
@@ -603,7 +607,7 @@ class SrGuiControllerTuner(Plugin):
         self.move_threads = []
 
     #########
-    #Default methods for the rosgui plugins
+    # Default methods for the rosgui plugins
 
     def _unregisterPublisher(self):
         if self._publisher is not None:

--- a/sr_gui_controller_tuner/src/sr_gui_controller_tuner/controller_tuner.py
+++ b/sr_gui_controller_tuner/src/sr_gui_controller_tuner/controller_tuner.py
@@ -291,6 +291,7 @@ class SrGuiControllerTuner(Plugin):
 
         #Reading the param that contains the config_dir suffix that we should use for this hand (e.g. '' normally for a right hand  or 'lh' if this is for a left hand)
         config_subdir = rospy.get_param('config_dir', '')
+        print "config_subdir: ",config_subdir
         subpath = "/controls/host/" + config_subdir
         if self.sr_controller_tuner_app_.edit_only_mode:
             filter_files = "*.yaml"

--- a/sr_gui_controller_tuner/src/sr_gui_controller_tuner/pid_loader_and_saver.py
+++ b/sr_gui_controller_tuner/src/sr_gui_controller_tuner/pid_loader_and_saver.py
@@ -26,6 +26,7 @@ try:
 except ImportError:
     from yaml import Loader, Dumper
 
+
 class PidLoader(object):
     """
     Loads pid parameters of each controller in parameters_dict from a yaml file
@@ -56,6 +57,7 @@ class PidLoader(object):
                 return -1
         return param_dict
 
+
 class PidSaver(object):
     """
     Saves pid parameters of each controller in parameters_dict in a yaml file
@@ -64,7 +66,7 @@ class PidSaver(object):
         self.path = file_path
 
     def save_settings(self, param_path, parameters_dict):
-        f = open(self.path,'r')
+        f = open(self.path, 'r')
         document = ""
         for line in f.readlines():
             document += line
@@ -92,7 +94,6 @@ if __name__ == '__main__':
         path_to_config = os.path.join(rospkg.RosPack().get_path("sr_edc_controller_configuration"))
 
         pid_saver = PidSaver(path_to_config+"/sr_edc_mixed_position_velocity_joint_controllers.yaml")
-        pid_saver.save_settings(["sh_wrj2_mixed_position_velocity_controller","pid"], {"d":1.0})
+        pid_saver.save_settings(["sh_wrj2_mixed_position_velocity_controller", "pid"], {"d": 1.0})
     except:
         rospy.logwarn("couldnt find the sr_edc_controller_configuration package")
-

--- a/sr_gui_controller_tuner/src/sr_gui_controller_tuner/sr_controller_tuner.py
+++ b/sr_gui_controller_tuner/src/sr_gui_controller_tuner/sr_controller_tuner.py
@@ -25,6 +25,7 @@ from controller_manager_msgs.srv import ListControllers
 from sr_robot_msgs.srv import ForceController, SetEffortControllerGains, SetMixedPositionVelocityPidGains, SetPidGains
 from sr_gui_controller_tuner.pid_loader_and_saver import PidLoader, PidSaver
 
+
 class CtrlSettings(object):
     """
     Parses xml file and reads controller settings
@@ -47,13 +48,13 @@ class CtrlSettings(object):
                 ctrl_tree = ctrl
                 break
 
-        if ctrl_tree == None:
+        if ctrl_tree is None:
             rospy.logerr("Couldn't find the settings for the controller " + controller_type)
 
         #read the headers settings
-        xml_headers = ctrl.find("headers")
+        xml_headers = ctrl_tree.find("headers")
         for header in xml_headers.findall("item"):
-            self.headers.append( header.attrib )
+            self.headers.append(header.attrib)
 
         self.nb_columns = len(self.headers)
 
@@ -65,17 +66,17 @@ class CtrlSettings(object):
         self.motors = []
         all_fingers = xml_tree.find("fingers")
         for finger in all_fingers.findall("finger"):
-            finger_row = [ finger.attrib['name'] ]
+            finger_row = [finger.attrib['name']]
             finger_row.extend((self.nb_columns - 1)*[""])
-            self.fingers.append( finger_row )
+            self.fingers.append(finger_row)
 
             motors_for_finger = []
             for motor in finger.findall("motor"):
-                motor_row = [ "", joint_prefix+motor.attrib['name'] ]
+                motor_row = ["", joint_prefix+motor.attrib['name']]
                 motor_row.extend((self.nb_columns - 1)*[""])
-                motors_for_finger.append( motor_row )
+                motors_for_finger.append(motor_row)
 
-            self.motors.append( motors_for_finger )
+            self.motors.append(motors_for_finger)
 
 
 class SrControllerTunerApp(object):
@@ -93,34 +94,33 @@ class SrControllerTunerApp(object):
         self.edit_only_mode = False
         self.control_mode = "FORCE"
         # global prefix
-        
+
         # prefix used in shadow controllers
-        self.controller_prefix="sh_"
-        
+        self.controller_prefix = "sh_"
+
         # both prefix and selected_prefix are stored
         # to handle case when gui is started in a namespace, then prefix
         # must be set to empty but selected prefix is still necessary
         # to select which joint_prefix to choose
-        self.selected_prefix=""
-        self.prefix=""
-        self.joint_prefix=""
+        self.selected_prefix = ""
+        self.prefix = ""
+        self.joint_prefix = ""
         # store if one or two loops are running
-        self.single_loop=False
-        
-        #TODO check that hand_id
-        self.namespace=rospy.get_namespace()
+        self.single_loop = False
+
+        self.namespace = rospy.get_namespace()
 
     def check_prefix(self):
         """
-        Get the prefix (hand and joint) 
+        Get the prefix (hand and joint)
         Check if it matches selected prefix
         """
-        
+
         hand_ids = []
         hand_joint_prefixes = []
         # unless imcompatible, use the selected prefix by default
-        self.prefix=self.selected_prefix
-        prefix= self.selected_prefix.rstrip("/")
+        self.prefix = self.selected_prefix
+        prefix = self.selected_prefix.rstrip("/")
         # mapping is always in global ns
         if rospy.has_param("/hand/mapping"):
             hand_mapping = rospy.get_param("/hand/mapping")
@@ -128,21 +128,21 @@ class SrControllerTunerApp(object):
                 # if prefix matches the mapping, add this hand (empty prefix means both hands)
                 if prefix in value:
                     hand_ids.append(value)
-        if len(hand_ids)==0:
+        if len(hand_ids) == 0:
             # no matching hand id to selected prefix, check for namespace
             if prefix in self.namespace:
                 rospy.loginfo("Using namespace, no prefix")
                 # in this case no prefix is needed
-                self.prefix=""
+                self.prefix = ""
             else:
                 rospy.logwarn("Prefix not matching namespace")
-                return False        
-                
-        if len(hand_ids)>1:
+                return False
+
+        if len(hand_ids) > 1:
             # the plugin cannot handle more than one hand
             rospy.logwarn("More than one hand found with prefix :"+prefix+" !\n Not loading controllers")
-            return False  
-        
+            return False
+
         # joint_prefix always in global ns
         if rospy.has_param("/hand/joint_prefix"):
             hand_joint_prefix_mapping = rospy.get_param("/hand/joint_prefix")
@@ -150,21 +150,20 @@ class SrControllerTunerApp(object):
                 # if prefix matches the mapping, add this joint prefix
                 if prefix in value:
                     hand_joint_prefixes.append(value)
-        
-        if len(hand_joint_prefixes)>1:
+
+        if len(hand_joint_prefixes) > 1:
             # the plugin cannot handle more than one hand
             rospy.logwarn("More than one hand found with prefix :"+prefix+" !\n Not loading controllers")
-            return False  
-                
+            return False
+
         if len(hand_joint_prefixes) == 0:
             rospy.logwarn("No hand found with prefix :"+prefix)
-            self.joint_prefix=""
-        else: 
-            self.joint_prefix=hand_joint_prefixes[0]
-        
+            self.joint_prefix = ""
+        else:
+            self.joint_prefix = hand_joint_prefixes[0]
+
         rospy.loginfo("using joint_prefix "+self.joint_prefix)
         return True
-
 
     def get_ctrls(self):
         """
@@ -172,24 +171,24 @@ class SrControllerTunerApp(object):
         return ["Motor Force", "Position"]
         """
         running_ctrls = []
-        
+
         # find controller manager in selected namespace
-        
+
         ctrl_srv_name = self.prefix+'controller_manager/list_controllers'
         try:
             rospy.wait_for_service(ctrl_srv_name, self.CONTROLLER_MANAGER_DETECTION_TIMEOUT)
 
-        except rospy.ROSException, e:
+        except rospy.ROSException:
             # try at root namespace (only in case bimanual setup in a single loop and only if no GUI ns)
-            if self.namespace=="/":
+            if self.namespace == "/":
                 ctrl_srv_name = 'controller_manager/list_controllers'
                 try:
                     rospy.wait_for_service(ctrl_srv_name, self.CONTROLLER_MANAGER_DETECTION_TIMEOUT)
-                    self.single_loop=True
+                    self.single_loop = True
                     rospy.loginfo("Detected single loop")
                 except rospy.ROSException, e:
-                    rospy.loginfo( "Controller manager not running: %s"%str(e) )
-                    rospy.loginfo( "Running controller tuner in edit-only mode" )
+                    rospy.loginfo("Controller manager not running: %s"%str(e))
+                    rospy.loginfo("Running controller tuner in edit-only mode")
                     self.edit_only_mode = True
                     #In edit_only_mode all the controllers are available for editing
                     for defined_ctrl_type in self.all_controller_types:
@@ -201,50 +200,49 @@ class SrControllerTunerApp(object):
                 for defined_ctrl_type in self.all_controller_types:
                     running_ctrls.append(defined_ctrl_type)
                 return running_ctrls
-          
+
         # found a controller manager
         controllers = rospy.ServiceProxy(ctrl_srv_name, ListControllers)
         resp = None
         try:
             resp = controllers()
         except rospy.ServiceException, e:
-            rospy.logerr( "Service did not process request: %s"%str(e) )
+            rospy.logerr("Service did not process request: %s"%str(e))
 
         running_ctrls.append("Motor Force")
-        if resp != None:
+        if resp is not None:
             for controller in resp.controller:
                 if controller.state == "running":
                     # find at the specific pattern of the controller
-                    splitted = re.split('[tfmrlw][fhr]j[0-5]_',controller.name)
+                    splitted = re.split('[tfmrlw][fhr]j[0-5]_', controller.name)
                     # only consider shadow (prefix sh_) controllers (drop js ctrl and others)
                     if self.controller_prefix in splitted[0]:
-                      ctrl_type_tmp=""
-                      # only consider joint controllers (containing _xxjy_)
-                      if len(splitted)>=2:
-                        ctrl_type_tmp = splitted[1]
-                      # look at first word of the controller type
-                      ctrl_type_tmp_splitted=ctrl_type_tmp.split("_")
-                      for defined_ctrl_type in self.all_controller_types:
-                          if ctrl_type_tmp_splitted[0].lower() in defined_ctrl_type.lower():
-                              running_ctrls.append(defined_ctrl_type)
-                              self.edit_only_mode = False
-                              return running_ctrls
-                    
-        rospy.loginfo( "No controllers currently running" )
-        rospy.loginfo( "Running controller tuner in edit-only mode" )
+                        ctrl_type_tmp = ""
+                        # only consider joint controllers (containing _xxjy_)
+                        if len(splitted) >= 2:
+                            ctrl_type_tmp = splitted[1]
+                        # look at first word of the controller type
+                        ctrl_type_tmp_splitted = ctrl_type_tmp.split("_")
+                        for defined_ctrl_type in self.all_controller_types:
+                            if ctrl_type_tmp_splitted[0].lower() in defined_ctrl_type.lower():
+                                running_ctrls.append(defined_ctrl_type)
+                                self.edit_only_mode = False
+                                return running_ctrls
+
+        rospy.loginfo("No controllers currently running")
+        rospy.loginfo("Running controller tuner in edit-only mode")
         self.edit_only_mode = True
         del running_ctrls[:]
         #In edit_only_mode all the controllers are available for editing
         for defined_ctrl_type in self.all_controller_types:
             running_ctrls.append(defined_ctrl_type)
-        
 
         return running_ctrls
 
     def refresh_control_mode(self):
-        self.control_mode = rospy.get_param('realtime_loop/'+self.prefix+'default_control_mode', 'FORCE')
+        self.control_mode = rospy.get_param('realtime_loop/' + self.prefix + 'default_control_mode', 'FORCE')
 
-    def get_controller_settings( self, controller_type ):
+    def get_controller_settings(self, controller_type):
         """
         Parses a file containing the controller settings
         and their min and max values, and returns them.
@@ -258,24 +256,24 @@ class SrControllerTunerApp(object):
         Load the parameters from the yaml file.
         """
         param_name = ""
-        prefix = self.prefix if self.single_loop!=True else ""
+        prefix = self.prefix if self.single_loop is not True else ""
         if controller_type == "Motor Force":
             # currently the motor_board topics use non-prefixed joint names
             # no matter if single or dual loops there is always a prefix for motors
-            param_name = self.prefix+joint_name.strip(self.joint_prefix.rstrip("/")+"_").lower() +"/pid"
+            param_name = self.prefix + joint_name.strip(self.joint_prefix.rstrip("/") + "_").lower() + "/pid"
         elif controller_type == "Position":
-            param_name =  prefix+self.controller_prefix+joint_name.lower()+"_position_controller/pid"
+            param_name = prefix + self.controller_prefix+joint_name.lower() + "_position_controller/pid"
         elif controller_type == "Muscle Position":
-            param_name =  prefix+self.controller_prefix+joint_name.lower()+"_muscle_position_controller/pid"
+            param_name = prefix + self.controller_prefix+joint_name.lower() + "_muscle_position_controller/pid"
         elif controller_type == "Velocity":
-            param_name =  prefix+self.controller_prefix+joint_name.lower()+"_velocity_controller/pid"
+            param_name = prefix + self.controller_prefix+joint_name.lower() + "_velocity_controller/pid"
         elif controller_type == "Mixed Position/Velocity":
-            param_name = [prefix+self.controller_prefix+joint_name.lower()+"_mixed_position_velocity_controller/position_pid",
-                          prefix+self.controller_prefix+joint_name.lower()+"_mixed_position_velocity_controller/velocity_pid" ]
+            param_name = [prefix + self.controller_prefix+joint_name.lower() + "_mixed_position_velocity_controller/position_pid",
+                          prefix + self.controller_prefix+joint_name.lower() + "_mixed_position_velocity_controller/velocity_pid"]
         elif controller_type == "Effort":
-            param_name =  prefix+self.controller_prefix+joint_name.lower()+"_effort_controller"
+            param_name = prefix + self.controller_prefix+joint_name.lower() + "_effort_controller"
 
-        return self.pid_loader.get_settings( param_name )
+        return self.pid_loader.get_settings(param_name)
 
     def set_controller(self, joint_name, controller_type, controller_settings):
         """
@@ -283,46 +281,46 @@ class SrControllerTunerApp(object):
         """
         pid_service = None
         service_name = ""
-        prefix = self.prefix if self.single_loop!=True else ""
-        
+        prefix = self.prefix if self.single_loop is not True else ""
+
         if controller_type == "Motor Force":
-            #/realtime_loop/change_force_PID_FFJ0 
+            #/realtime_loop/change_force_PID_FFJ0
             # currently use non-prefixed joint names but adds prefix in the middle
             # no matter if single or dual loops there is always a prefix for motors
-            service_name =  "realtime_loop/"+self.prefix+"change_force_PID_"+joint_name[-4:].upper()
+            service_name = "realtime_loop/"+self.prefix+"change_force_PID_"+joint_name[-4:].upper()
             pid_service = rospy.ServiceProxy(service_name, ForceController)
 
         elif controller_type == "Position":
             #/sh_ffj3_position_controller/set_gains
-            service_name =  prefix+self.controller_prefix+joint_namejoint_name.lower()+"_position_controller/set_gains"
+            service_name = prefix+self.controller_prefix+joint_name.lower()+"_position_controller/set_gains"
             pid_service = rospy.ServiceProxy(service_name, SetPidGains)
 
         elif controller_type == "Muscle Position":
             #/sh_ffj3_position_controller/set_gains
-            service_name =  prefix+self.controller_prefix+joint_name.lower()+"_muscle_position_controller/set_gains"
+            service_name = prefix+self.controller_prefix+joint_name.lower()+"_muscle_position_controller/set_gains"
             pid_service = rospy.ServiceProxy(service_name, SetPidGains)
 
         elif controller_type == "Velocity":
             #/sh_ffj3_velocity_controller/set_gains
-            service_name =  prefix+self.controller_prefix+joint_name.lower()+"_velocity_controller/set_gains"
+            service_name = prefix+self.controller_prefix+joint_name.lower()+"_velocity_controller/set_gains"
             pid_service = rospy.ServiceProxy(service_name, SetPidGains)
 
         elif controller_type == "Mixed Position/Velocity":
             #/sh_ffj3_mixed_position_velocity_controller/set_gains
-            service_name =  prefix+self.controller_prefix+joint_name.lower()+"_mixed_position_velocity_controller/set_gains"
+            service_name = prefix+self.controller_prefix+joint_name.lower()+"_mixed_position_velocity_controller/set_gains"
             pid_service = rospy.ServiceProxy(service_name, SetMixedPositionVelocityPidGains)
 
         elif controller_type == "Effort":
             #/sh_ffj3_effort_controller/set_gains
-            service_name =  prefix+self.controller_prefix+joint_name.lower()+"_effort_controller/set_gains"
+            service_name = prefix+self.controller_prefix+joint_name.lower()+"_effort_controller/set_gains"
             pid_service = rospy.ServiceProxy(service_name, SetEffortControllerGains)
 
         else:
-            rospy.logerr( "", controller_type, " is not a recognized controller type." )
+            rospy.logerr("", controller_type, " is not a recognized controller type.")
 
         contrlr_settings_converted = {}
         for param in controller_settings.items():
-            contrlr_settings_converted[ param[0] ] = float(param[1])
+            contrlr_settings_converted[param[0]] = float(param[1])
 
         if controller_type == "Motor Force":
             try:
@@ -332,8 +330,8 @@ class SrControllerTunerApp(object):
                             int(contrlr_settings_converted["f"]),
                             int(contrlr_settings_converted["p"]), int(contrlr_settings_converted["i"]),
                             int(contrlr_settings_converted["d"]), int(contrlr_settings_converted["imax"]),
-                            int(contrlr_settings_converted["deadband"]), int(contrlr_settings_converted["sign"]) )
-            except:
+                            int(contrlr_settings_converted["deadband"]), int(contrlr_settings_converted["sign"]))
+            except rospy.ServiceException:
                 return False
 
         elif controller_type == "Position":
@@ -341,8 +339,8 @@ class SrControllerTunerApp(object):
                 pid_service(float(contrlr_settings_converted["p"]), float(contrlr_settings_converted["i"]),
                             float(contrlr_settings_converted["d"]), float(contrlr_settings_converted["i_clamp"]),
                             float(contrlr_settings_converted["max_force"]), float(contrlr_settings_converted["position_deadband"]),
-                            int(contrlr_settings_converted["friction_deadband"]) )
-            except:
+                            int(contrlr_settings_converted["friction_deadband"]))
+            except rospy.ServiceException:
                 return False
 
         elif controller_type == "Muscle Position":
@@ -350,8 +348,8 @@ class SrControllerTunerApp(object):
                 pid_service(float(contrlr_settings_converted["p"]), float(contrlr_settings_converted["i"]),
                             float(contrlr_settings_converted["d"]), float(contrlr_settings_converted["i_clamp"]),
                             float(contrlr_settings_converted["max_force"]), float(contrlr_settings_converted["position_deadband"]),
-                            int(contrlr_settings_converted["friction_deadband"]) )
-            except:
+                            int(contrlr_settings_converted["friction_deadband"]))
+            except rospy.ServiceException:
                 return False
 
         elif controller_type == "Velocity":
@@ -359,8 +357,8 @@ class SrControllerTunerApp(object):
                 pid_service(float(contrlr_settings_converted["p"]), float(contrlr_settings_converted["i"]),
                             float(contrlr_settings_converted["d"]), float(contrlr_settings_converted["i_clamp"]),
                             float(contrlr_settings_converted["max_force"]), float(contrlr_settings_converted["velocity_deadband"]),
-                            int(contrlr_settings_converted["friction_deadband"]) )
-            except:
+                            int(contrlr_settings_converted["friction_deadband"]))
+            except rospy.ServiceException:
                 return False
 
         elif controller_type == "Mixed Position/Velocity":
@@ -372,38 +370,37 @@ class SrControllerTunerApp(object):
                             float(contrlr_settings_converted["vel/p"]), float(contrlr_settings_converted["vel/i"]),
                             float(contrlr_settings_converted["vel/d"]), float(contrlr_settings_converted["vel/i_clamp"]),
                             float(contrlr_settings_converted["vel/max_force"]),
-                            int(contrlr_settings_converted["vel/friction_deadband"]) )
-            except:
+                            int(contrlr_settings_converted["vel/friction_deadband"]))
+            except rospy.ServiceException:
                 return False
 
         elif controller_type == "Effort":
             try:
-                pid_service(int(contrlr_settings_converted["max_force"]), int(contrlr_settings_converted["friction_deadband"]) )
-            except:
+                pid_service(int(contrlr_settings_converted["max_force"]), int(contrlr_settings_converted["friction_deadband"]))
+            except rospy.ServiceException:
                 return False
         else:
-            rospy.logerr( "", controller_type, " is not a recognized controller type." )
+            rospy.logerr("", controller_type, " is not a recognized controller type.")
             return False
         return True
-
 
     def save_controller(self, joint_name, controller_type, controller_settings, filename):
         """
         Saves the controller settings calling the proper service with the correct syntax for controller type
         """
         param_name = []
-        prefix = self.prefix if self.single_loop!=True else ""
+        prefix = self.prefix if self.single_loop is not True else ""
         if controller_type == "Motor Force":
-            param_name = [""+joint_name[-4:].lower() ,"pid"]
+            param_name = ["" + joint_name[-4:].lower(), "pid"]
         elif controller_type == "Position":
-            param_name =  [prefix+self.controller_prefix+joint_name.lower()+"_position_controller" , "pid"]
+            param_name = [prefix + self.controller_prefix + joint_name.lower() + "_position_controller", "pid"]
         elif controller_type == "Muscle Position":
-            param_name =  [prefix+self.controller_prefix+joint_name.lower()+"_muscle_position_controller" , "pid"]
+            param_name = [prefix + self.controller_prefix + joint_name.lower() + "_muscle_position_controller", "pid"]
         elif controller_type == "Velocity":
-            param_name =  [prefix+self.controller_prefix+joint_name.lower()+"_velocity_controller" , "pid"]
+            param_name = [prefix + self.controller_prefix + joint_name.lower() + "_velocity_controller", "pid"]
         elif controller_type == "Mixed Position/Velocity":
-            param_name =  [prefix+self.controller_prefix+joint_name.lower()+"_mixed_position_velocity_controller" , "pid"]
+            param_name = [prefix + self.controller_prefix + joint_name.lower() + "_mixed_position_velocity_controller", "pid"]
         elif controller_type == "Effort":
-            param_name =  [prefix+self.controller_prefix+joint_name.lower()+"_effort_controller"]
+            param_name = [prefix + self.controller_prefix + joint_name.lower() + "_effort_controller"]
         pid_saver = PidSaver(filename)
         pid_saver.save_settings(param_name, controller_settings)

--- a/sr_gui_controller_tuner/uis/SrGuiControllerTuner.ui
+++ b/sr_gui_controller_tuner/uis/SrGuiControllerTuner.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>ControllerDockWidget</class>
  <widget class="QWidget" name="ControllerDockWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>626</width>
+    <height>286</height>
+   </rect>
+  </property>
   <property name="sizePolicy">
    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
     <horstretch>0</horstretch>
@@ -19,6 +27,36 @@
      </property>
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Hand Prefix</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="select_prefix"/>
+         </item>
+        </layout>
+       </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>


### PR DESCRIPTION
I struggled (due to that https://github.com/shadow-robot/sr-ros-interface-ethercat/issues/56 ) but managed to add support for bimanual hand in the controller tuner.

Getting it to work with the sr_bimanual.launch was one thing, getting it to work when the GUI is loaded in a namespace was a more complex step.
I need to use prefix, joint_prefix and namespace to really identify the situation. 

I also added a small change in handling the checkbox value, this is necessary for an upcoming other boolean parameter I will PR soon.

Now, it is possible to start the controller tuner for almost anycase. All of the one listed here down were tested for motor->set/load/save and host->set/load/save/move/plot
- sr_bimanual + GUI without NS
- sr_edc_launch with use_ns=use_prefix=1 + GUI without NS
- sr_edc_launch with use_ns=use_prefix=0 + GUI without NS
- sr_edc_launch in a namespace with use_ns=0 use_prefix=1 + GUI with and without NS

I hope I covered all the use case. Please give it a try in production. It really helps a lot to have a controller tuner working with prefixes/namespaces
