### PR TITLE
Fix hand_calibration for PyQt5

### DIFF
--- a/basic/sr_gui_hand_calibration/src/sr_gui_hand_calibration/hand_calibration.py
+++ b/basic/sr_gui_hand_calibration/src/sr_gui_hand_calibration/hand_calibration.py
@@ -21,13 +21,13 @@ import rospy
 import rospkg
 
 from qt_gui.plugin import Plugin
-from python_qt_binding import loadUi
+from PyQt5.uic import loadUi
 
-from QtCore import QEvent, QObject, Qt, QTimer, Slot
-from QtGui import QWidget, QShortcut, QColor, QTreeWidgetItem, QFileDialog, QMessageBox
-from QtCore import QVariant
+from PyQt5.QtCore import QEvent, QObject, Qt, QTimer, Slot
+from PyQt5.QtGui import QColor
+from PyQt5.QtWidgets import QWidget, QShortcut, QTreeWidgetItem, QFileDialog, QMessageBox
+from PyQt5.QtCore import QVariant
 from sr_gui_hand_calibration.sr_hand_calibration_model import HandCalibration
-
 
 class SrHandCalibration(Plugin):
 

--- a/basic/sr_gui_hand_calibration/src/sr_gui_hand_calibration/hand_calibration.py
+++ b/basic/sr_gui_hand_calibration/src/sr_gui_hand_calibration/hand_calibration.py
@@ -29,6 +29,7 @@ from PyQt5.QtWidgets import QWidget, QShortcut, QTreeWidgetItem, QFileDialog, QM
 from PyQt5.QtCore import QVariant
 from sr_gui_hand_calibration.sr_hand_calibration_model import HandCalibration
 
+
 class SrHandCalibration(Plugin):
 
     """

--- a/basic/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
+++ b/basic/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
@@ -19,9 +19,9 @@
 import rospy
 
 from sr_robot_lib.etherCAT_hand_lib import EtherCAT_Hand_Lib
-from QtGui import QTreeWidgetItem, QTreeWidgetItemIterator, QColor, QIcon, QMessageBox
-from PyQt4.Qt import QTimer
-from PyQt4.QtCore import SIGNAL
+from PyQt5.QtGui import QColor, QIcon
+from PyQt5.QtWidgets import QTreeWidget, QTreeWidgetItem, QTreeWidgetItemIterator, QMessageBox
+from PyQt5.QtCore import QTimer, pyqtSignal
 
 import yaml
 try:
@@ -59,7 +59,7 @@ class IndividualCalibration(QTreeWidgetItem):
                                  "", "", str(self.raw_value), str(self.calibrated_value)])
 
         for col in xrange(self.tree_widget.columnCount()):
-            self.setBackgroundColor(col, QColor(red))
+            self.setBackground(col, QColor(red))
 
         self.tree_widget.addTopLevelItem(self)
 
@@ -79,7 +79,7 @@ class IndividualCalibration(QTreeWidgetItem):
 
         for col in xrange(self.tree_widget.columnCount()):
             if self.text(2) != "":
-                self.setBackgroundColor(col, QColor(green))
+                self.setBackground(col, QColor(green))
 
         self.is_calibrated = True
 
@@ -90,7 +90,7 @@ class IndividualCalibration(QTreeWidgetItem):
         """
         for col in xrange(self.tree_widget.columnCount()):
             if self.text(2) != "":
-                self.setBackgroundColor(col, QColor(orange))
+                self.setBackground(col, QColor(orange))
 
         self.is_calibrated = True
 
@@ -130,9 +130,9 @@ class JointCalibration(QTreeWidgetItem):
         # display the current joint position in the GUI
         self.timer = QTimer()
         self.timer.start(200)
+
         tree_widget.addTopLevelItem(self)
-        tree_widget.connect(
-            self.timer, SIGNAL('timeout()'), self.update_joint_pos)
+        self.timer.timeout.connect(self.update_joint_pos)
 
     def load_joint_calibration(self, new_calibrations):
         for calibration in self.calibrations:
@@ -407,9 +407,9 @@ class HandCalibration(QTreeWidgetItem):
         self.progress()
 
         # select the next row by default
-        self.tree_widget.setItemSelected(item, False)
+        item.setSelected(False)
         next_item = self.tree_widget.itemBelow(item)
-        self.tree_widget.setItemSelected(next_item, True)
+        next_item.setSelected(True)
         self.tree_widget.setCurrentItem(next_item)
 
     def calibrate_joint0s(self, btn_joint_0s):


### PR DESCRIPTION
hand calibration was failing on Xenial/kinetic, due to imports. Once fixed it was segfaulting due to mixed up loading PyQt4 and PyQt5 somehow.
The loadUI was PyQt4 which made the created objects (like treewidget) Qt4 and not compatible.
I think it is all fixed now, hopefully in a way you like