### PR TITLE
Updated imports for Qt

### DIFF
--- a/sr_gui_change_controllers/src/sr_gui_change_controllers/change_controllers.py
+++ b/sr_gui_change_controllers/src/sr_gui_change_controllers/change_controllers.py
@@ -6,7 +6,7 @@
 import os
 from python_qt_binding import loadUi
 from qt_gui.plugin import Plugin
-from QtGui import QWidget
+from QtWidgets import QWidget
 import rospy
 import rospkg
 from sr_robot_msgs.srv import RobotTeachMode, RobotTeachModeRequest, RobotTeachModeResponse


### PR DESCRIPTION
Using:
roslaunch sr_robot_launch srhand.launch sim:=true

RQT spits out:
[INFO] [1490718861.084203, 1043.491000]: Changing robot left_arm to mode 0
[ERROR] [1490718861.096327, 1043.493000]: Failed to call service teach_mode

Which is the same as when run with Indigo version so assumed to be working okay. Would be good to test with real hand as believe error is due to no hand being connected.