### PR TITLE
Update repository.rosinstall

### DIFF
--- a/repository.rosinstall
+++ b/repository.rosinstall
@@ -19,6 +19,6 @@
     version: 'kinetic-devel'
     
 - git:
-    local-name: sr-teleop
+    local-name: sr_teleop
     uri: https://github.com/shadow-robot/sr-teleop.git
     version: kinetic-devel


### PR DESCRIPTION
Changing sr_teleop source dependency local name (checkout location) to align with e.g. [one-liner](https://github.com/shadow-robot/sr-build-tools/blob/7684b896eb20b4198adef203fd929fb47f0fb95d/data/shadow_robot-kinetic.rosinstall#L37).