### PR TITLE
[sr_gui_hand_calibration] Protected next item for last item of the list

### DIFF
--- a/basic/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
+++ b/basic/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
@@ -407,10 +407,11 @@ class HandCalibration(QTreeWidgetItem):
         self.progress()
 
         # select the next row by default
-        item.setSelected(False)
         next_item = self.tree_widget.itemBelow(item)
-        next_item.setSelected(True)
-        self.tree_widget.setCurrentItem(next_item)
+        if next_item is not None:
+            item.setSelected(False)
+            next_item.setSelected(True)
+            self.tree_widget.setCurrentItem(next_item)
 
     def calibrate_joint0s(self, btn_joint_0s):
         joint0s = ["FFJ1", "FFJ2",


### PR DESCRIPTION
Without this fix, when double clicking on WRJ2, last element on the list the plugin crashes (and one lose all previously calibrated joints ...)