### PR TITLE
Fix data visualization bug

### DIFF
--- a/sr_data_visualization/scripts/sr_data_visualization/sr_data_visualizer_gui.py
+++ b/sr_data_visualization/scripts/sr_data_visualization/sr_data_visualizer_gui.py
@@ -65,10 +65,10 @@ class SrDataVisualizer(Plugin):
         self._widget = QWidget()
         self._hand_finder = HandFinder()
         self._hand_parameters = self._hand_finder.get_hand_parameters()
-        self._joint_prefix = self._hand_parameters.joint_prefix
+        self._joint_prefix = next(iter(self._hand_parameters.joint_prefix.values()))
         self._hand_g = False
         for hand, joints in self._hand_finder.hand_joints.items():
-            if 'THJ3' not in joints:
+            if self._joint_prefix + 'WRJ1' not in joints:
                 self._hand_g = True
         for key in self._hand_parameters.joint_prefix:
             self.hand_serial = key


### PR DESCRIPTION
## Proposed changes

PR to fix data visualisation plugin bug. The joint prefix was not correctly retrieved. Moreover the condition to define whether the hand was a dexterous hand or an hand lite was not working properly. As a result, we were always setting hand visualiser with the hand lite config file.

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [x] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [x] Tested on real hardware (if the changed or added code is used with the real hardware).
- [x] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
