### PR TITLE
Added missing resource and uis install for sr_data_visualization

### DIFF
--- a/sr_data_visualization/CMakeLists.txt
+++ b/sr_data_visualization/CMakeLists.txt
@@ -20,6 +20,6 @@ catkin_package(
     sr_robot_msgs
 )
 
-install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+install(DIRECTORY launch uis resource DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install( FILES sr_data_visualizer_plugin.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION} )
 


### PR DESCRIPTION
## Proposed changes

Added missing install for resource, causing a fail at start of rqt
`UserWarning: icon "/vol/famula/nightly/ros/melodic/share/sr_data_visualization/resource/hand.png" not found`

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [x] ~~Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).~~
- [x] Tested on real hardware (if the changed or added code is used with the real hardware).
- [x] ~~Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)~~
