### PR TITLE
Fix access to response

### DIFF
--- a/advanced/sr_gui_advanced_controls/src/sr_gui_advanced_controls/advanced_controls.py
+++ b/advanced/sr_gui_advanced_controls/src/sr_gui_advanced_controls/advanced_controls.py
@@ -345,10 +345,11 @@ class SrGuiAdvancedControls(Plugin):
                             'controller_manager/load_controller',
                             LoadController)
                         resp1 = load_controllers(load_control)
+                        if not resp1.ok:
+                            success = False
                     except rospy.ServiceException:
                         success = False
-                    if not resp1.ok:
-                        success = False
+                    
 
             switch_controllers = rospy.ServiceProxy(
                 'controller_manager/switch_controller', SwitchController)

--- a/advanced/sr_gui_advanced_controls/src/sr_gui_advanced_controls/advanced_controls.py
+++ b/advanced/sr_gui_advanced_controls/src/sr_gui_advanced_controls/advanced_controls.py
@@ -349,7 +349,6 @@ class SrGuiAdvancedControls(Plugin):
                             success = False
                     except rospy.ServiceException:
                         success = False
-                    
 
             switch_controllers = rospy.ServiceProxy(
                 'controller_manager/switch_controller', SwitchController)


### PR DESCRIPTION
## Proposed changes

Bugfix: `resp1.ok` should be evaluated as part of `try` block. Otherwise, if the service call fails, it might be undefined.
Actually it isn't because it's still defined from the previous call in (but we don't want to use that value either):
https://github.com/shadow-robot/sr-visualization/blob/585dfff314228132abb8765912474ada8172a14a/advanced/sr_gui_advanced_controls/src/sr_gui_advanced_controls/advanced_controls.py#L328

**Needs forward port to noetic-devel.**

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [x] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added automated tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
