### PR TITLE
fix building error

### DIFF
--- a/sr_fingertip_visualization/package.xml
+++ b/sr_fingertip_visualization/package.xml
@@ -19,6 +19,7 @@
   <build_depend>rqt_gui_py</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>sr_robot_msgs</build_depend>
+  <build_depend>sr_visualization_icons</build_depend>
 
   <run_depend>rospy</run_depend>
   <run_depend>rqt_gui</run_depend>
@@ -28,6 +29,7 @@
   <run_depend version_gte="0.2.19">python_qt_binding</run_depend>
   <run_depend>qwt_dependency</run_depend>
   <run_depend>python3-qwt</run_depend>
+  <run_depend>sr_visualization_icons</run_depend>
 
   <export>
     <rqt_gui plugin="${prefix}/sr_fingertip_plugin_gui.xml"/>


### PR DESCRIPTION
This package requires sr_visualization_icons to build, and this patch fixes it.
