### PR TITLE
Solve bug Unfiltered position and force traces not shown

### DIFF
--- a/sr_data_visualization/src/sr_data_visualization/data_tab.py
+++ b/sr_data_visualization/src/sr_data_visualization/data_tab.py
@@ -265,8 +265,8 @@ class MotorStats2DataTab(MotorGroupsDataTab):
     def optional_button_connections(self):
         self.tab_options.effort_button.toggled.connect(lambda: self.radio_button_selected("Measured Effort"))
         self.tab_options.temp_button.toggled.connect(lambda: self.radio_button_selected("Temperature"))
-        self.tab_options.unf_position_button.toggled.connect(lambda: self.radio_button_selected("Unfiltered Position"))
-        self.tab_options.unf_force_button.toggled.connect(lambda: self.radio_button_selected("Unfiltered Force"))
+        self.tab_options.unf_position_button.toggled.connect(lambda: self.radio_button_selected("Unfiltered position"))
+        self.tab_options.unf_force_button.toggled.connect(lambda: self.radio_button_selected("Unfiltered force"))
         self.tab_options.last_effort_button.toggled.connect(lambda: self.radio_button_selected("Last Commanded Effort"))
         self.tab_options.encoder_pos_button.toggled.connect(lambda: self.radio_button_selected("Encoder Position"))
 


### PR DESCRIPTION
## Proposed changes

PR to solve that Unfiltered Position and Force traces are not shown on the displays of the 2 Motor Stats.

Data is properly received in the /diagnostics_agg topic, but there seems to be a missmatch when comparing the trace.name with the radio button name in [show_trace](https://github.com/shadow-robot/sr-visualization/blob/c4f666d8deaaea42a5dd6e64b4e9b0d672324501/sr_data_visualization/src/sr_data_visualization/data_plot.py#L108) function. The string trace.name is [“Unfiltered position“](https://github.com/shadow-robot/sr-visualization/blob/c4f666d8deaaea42a5dd6e64b4e9b0d672324501/sr_data_visualization/src/sr_data_visualization/data_plot.py#L199) while the name of the radio button is [“Unfiltered Position“](https://github.com/shadow-robot/sr-visualization/blob/c4f666d8deaaea42a5dd6e64b4e9b0d672324501/sr_data_visualization/src/sr_data_visualization/data_tab.py#L268) so the condition is not met and the trace is not shown. [Here](https://github.com/shadow-robot/sr-visualization/blob/c4f666d8deaaea42a5dd6e64b4e9b0d672324501/sr_data_visualization/src/sr_data_visualization/data_tab.py#L93) is were the name of the radio button is introduced to show_trace. The same happens with Unfiltered Force.

I lowered case the name introduced to the radio_button_selected function so that the condition is met and the trace is shown. The name of the radio button remains the same.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [x] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [x] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
