### PR TITLE
Fixed issue with bootloader GUI when in server_and_nuc deployed scenario

### DIFF
--- a/advanced/sr_gui_bootloader/src/sr_gui_bootloader/bootloader.py
+++ b/advanced/sr_gui_bootloader/src/sr_gui_bootloader/bootloader.py
@@ -18,7 +18,7 @@ import rosnode
 import rospkg
 from QtCore import Qt, QThread, QPoint, pyqtSignal
 from QtGui import QColor
-from QtWidgets import {
+from QtWidgets import (
     QWidget,
     QMessageBox,
     QFrame,
@@ -28,7 +28,7 @@ from QtWidgets import {
     QFileDialog,
     QApplication,
     QVBoxLayout
-}
+)
 from qt_gui.plugin import Plugin
 from python_qt_binding import loadUi
 from sr_utilities.hand_finder import HandFinder
@@ -102,7 +102,6 @@ class SrGuiBootloader(Plugin):
 
     def __init__(self, context):
         super().__init__(context)
-        rospy.logwarn(rospy.get_name())
         self.setObjectName('SrGuiBootloader')
 
         self._publisher = None

--- a/advanced/sr_gui_bootloader/src/sr_gui_bootloader/bootloader.py
+++ b/advanced/sr_gui_bootloader/src/sr_gui_bootloader/bootloader.py
@@ -14,16 +14,19 @@
 import sys
 import os
 import rospy
+import rosnode
 import rospkg
 from QtCore import Qt, QThread, QPoint, pyqtSignal
 from QtGui import QColor
-from QtWidgets import QWidget, QMessageBox, QFrame, QHBoxLayout, QCheckBox, QLabel, QFileDialog, QApplication
+from QtWidgets import QWidget, QMessageBox, QFrame, QHBoxLayout, QCheckBox, QLabel, QFileDialog, QApplication, QVBoxLayout
 from qt_gui.plugin import Plugin
 from python_qt_binding import loadUi
 from sr_utilities.hand_finder import HandFinder
 from diagnostic_msgs.msg import DiagnosticArray
 from sr_robot_msgs.srv import SimpleMotorFlasher, SimpleMotorFlasherResponse
 
+SERVER_MACHINE_NAME = os.uname()[1]
+CONTROL_MACHINE_NAME = "nuc-control"
 
 class MotorBootloader(QThread):
 
@@ -87,52 +90,74 @@ class SrGuiBootloader(Plugin):
     A GUI plugin for bootloading the motors on the shadow etherCAT hand.
     """
 
-    def __init__(self, context):
+    def __init__(self, context):        
         super().__init__(context)
+        rospy.logwarn(rospy.get_name())
         self.setObjectName('SrGuiBootloader')
 
         self._publisher = None
         self._widget = QWidget()
 
-        ui_file = os.path.join(rospkg.RosPack().get_path(
-            'sr_gui_bootloader'), 'uis', 'SrBootloader.ui')
-        loadUi(ui_file, self._widget)
-        self._widget.setObjectName('SrMotorResetterUi')
-        if context is not None:
-            context.add_widget(self._widget)
+        correct = self._is_plugin_launched_on_correct_machine()
+        rospy.logwarn(f"Plugin launched:{correct}") 
 
-        # setting the prefixes
-        self._hand_finder = HandFinder()
-        hand_parameters = self._hand_finder.get_hand_parameters()
-        self._prefix = ""
-        for hand in hand_parameters.mapping:
-            self._widget.select_prefix.addItem(hand_parameters.mapping[hand])
-        if not hand_parameters.mapping:
-            rospy.logerr("No hand detected")
-            QMessageBox.warning(self._widget, "warning", "No hand is detected")
-            return
-        self._widget.select_prefix.setCurrentIndex(0)
-        self._prefix = list(hand_parameters.mapping.values())[0]
-        self._widget.select_prefix.currentIndexChanged['QString'].connect(self.prefix_selected)
+        if correct:
+            ui_file = os.path.join(rospkg.RosPack().get_path(
+                'sr_gui_bootloader'), 'uis', 'SrBootloader.ui')
+            loadUi(ui_file, self._widget)
+            self._widget.setObjectName('SrMotorResetterUi')
 
-        # motors_frame is defined in the ui file with a grid layout
-        self.motors = []
-        self.motors_frame = self._widget.motors_frame
-        self.motor_bootloader = None
-        self.progress_bar = self._widget.motors_progress_bar
-        self.progress_bar.hide()
+            if context is not None:
+                context.add_widget(self._widget)
 
-        self.server_revision = 0
-        self.diag_sub = rospy.Subscriber("/diagnostics", DiagnosticArray, self.diagnostics_callback)
+            # setting the prefixes
+            self._hand_finder = HandFinder()
+            hand_parameters = self._hand_finder.get_hand_parameters()
+            self._prefix = ""
+            for hand in hand_parameters.mapping:
+                self._widget.select_prefix.addItem(hand_parameters.mapping[hand])
+            if not hand_parameters.mapping:
+                rospy.logerr("No hand detected")
+                QMessageBox.warning(self._widget, "warning", "No hand is detected")
+                return
+            self._widget.select_prefix.setCurrentIndex(0)
+            self._prefix = list(hand_parameters.mapping.values())[0]
+            self._widget.select_prefix.currentIndexChanged['QString'].connect(self.prefix_selected)
 
-        # Bind button clicks
-        self._widget.btn_select_bootloader.pressed.connect(self.on_select_bootloader_pressed)
-        self._widget.btn_select_all.pressed.connect(self.on_select_all_pressed)
-        self._widget.btn_select_none.pressed.connect(self.on_select_none_pressed)
-        self._widget.btn_bootload.pressed.connect(self.on_bootload_pressed)
+            # motors_frame is defined in the ui file with a grid layout
+            self.motors = []
+            self.motors_frame = self._widget.motors_frame
+            self.motor_bootloader = None
+            self.progress_bar = self._widget.motors_progress_bar
+            self.progress_bar.hide()
 
-        # select the first available hand
-        self.prefix_selected(list(hand_parameters.mapping.values())[0])
+            self.server_revision = 0
+            self.diag_sub = rospy.Subscriber("/diagnostics", DiagnosticArray, self.diagnostics_callback)
+
+            # Bind button clicks
+            self._widget.btn_select_bootloader.pressed.connect(self.on_select_bootloader_pressed)
+            self._widget.btn_select_all.pressed.connect(self.on_select_all_pressed)
+            self._widget.btn_select_none.pressed.connect(self.on_select_none_pressed)
+            self._widget.btn_bootload.pressed.connect(self.on_bootload_pressed)
+
+            # select the first available hand
+            self.prefix_selected(list(hand_parameters.mapping.values())[0])
+
+        else:
+            layout = QVBoxLayout()
+            fault_label = QLabel("Please launch this plugin via RQT NUC")
+            fault_label.setAlignment(Qt.AlignCenter)
+            layout.addWidget(fault_label)
+            self._widget.setLayout(layout)
+            if context is not None:
+                context.add_widget(self._widget)
+
+    def _is_plugin_launched_on_correct_machine(self):
+        machine_list = rosnode.get_machines_by_nodes()
+        rospy.logwarn(f"Available machines:{machine_list}")
+        if CONTROL_MACHINE_NAME in machine_list:
+            return rospy.get_name() in rosnode.get_nodes_by_machine(CONTROL_MACHINE_NAME)
+        return True
 
     def on_select_bootloader_pressed(self):
         """
@@ -306,7 +331,6 @@ class SrGuiBootloader(Plugin):
 
 
 if __name__ == "__main__":
-    rospy.init_node("bootloader")
     app = QApplication(sys.argv)
     ctrl = SrGuiBootloader(None)
     ctrl._widget.show()  # pylint: disable=W0212

--- a/advanced/sr_gui_bootloader/src/sr_gui_bootloader/bootloader.py
+++ b/advanced/sr_gui_bootloader/src/sr_gui_bootloader/bootloader.py
@@ -18,15 +18,25 @@ import rosnode
 import rospkg
 from QtCore import Qt, QThread, QPoint, pyqtSignal
 from QtGui import QColor
-from QtWidgets import QWidget, QMessageBox, QFrame, QHBoxLayout, QCheckBox, QLabel, QFileDialog, QApplication, QVBoxLayout
+from QtWidgets import {
+    QWidget,
+    QMessageBox,
+    QFrame,
+    QHBoxLayout,
+    QCheckBox,
+    QLabel,
+    QFileDialog,
+    QApplication,
+    QVBoxLayout
+}
 from qt_gui.plugin import Plugin
 from python_qt_binding import loadUi
 from sr_utilities.hand_finder import HandFinder
 from diagnostic_msgs.msg import DiagnosticArray
 from sr_robot_msgs.srv import SimpleMotorFlasher, SimpleMotorFlasherResponse
 
-SERVER_MACHINE_NAME = os.uname()[1]
 CONTROL_MACHINE_NAME = "nuc-control"
+
 
 class MotorBootloader(QThread):
 
@@ -90,7 +100,7 @@ class SrGuiBootloader(Plugin):
     A GUI plugin for bootloading the motors on the shadow etherCAT hand.
     """
 
-    def __init__(self, context):        
+    def __init__(self, context):
         super().__init__(context)
         rospy.logwarn(rospy.get_name())
         self.setObjectName('SrGuiBootloader')
@@ -98,10 +108,7 @@ class SrGuiBootloader(Plugin):
         self._publisher = None
         self._widget = QWidget()
 
-        correct = self._is_plugin_launched_on_correct_machine()
-        rospy.logwarn(f"Plugin launched:{correct}") 
-
-        if correct:
+        if self._is_plugin_launched_on_correct_machine():
             ui_file = os.path.join(rospkg.RosPack().get_path(
                 'sr_gui_bootloader'), 'uis', 'SrBootloader.ui')
             loadUi(ui_file, self._widget)
@@ -154,7 +161,6 @@ class SrGuiBootloader(Plugin):
 
     def _is_plugin_launched_on_correct_machine(self):
         machine_list = rosnode.get_machines_by_nodes()
-        rospy.logwarn(f"Available machines:{machine_list}")
         if CONTROL_MACHINE_NAME in machine_list:
             return rospy.get_name() in rosnode.get_nodes_by_machine(CONTROL_MACHINE_NAME)
         return True

--- a/advanced/sr_gui_bootloader/src/sr_gui_bootloader/bootloader.py
+++ b/advanced/sr_gui_bootloader/src/sr_gui_bootloader/bootloader.py
@@ -113,7 +113,7 @@ class SrGuiBootloader(Plugin):
             loadUi(ui_file, self._widget)
             self._widget.setObjectName('SrMotorResetterUi')
 
-            if context is not None:
+            if context:
                 context.add_widget(self._widget)
 
             # setting the prefixes
@@ -155,7 +155,7 @@ class SrGuiBootloader(Plugin):
             fault_label.setAlignment(Qt.AlignCenter)
             layout.addWidget(fault_label)
             self._widget.setLayout(layout)
-            if context is not None:
+            if context:
                 context.add_widget(self._widget)
 
     def _is_plugin_launched_on_correct_machine(self):
@@ -336,6 +336,7 @@ class SrGuiBootloader(Plugin):
 
 
 if __name__ == "__main__":
+    rospy.init_node("bootloader")
     app = QApplication(sys.argv)
     ctrl = SrGuiBootloader(None)
     ctrl._widget.show()  # pylint: disable=W0212


### PR DESCRIPTION
## Proposed changes

User Story: https://shadowrobot.atlassian.net/browse/SP-299

Bootloader plugin has no warning about being launched on server laptop
Fixing issue when bootloader GUI ran on the server when using NUC.

If GUI launched on server in 'server and nuc' scenario you'll get the info below. If launched via RQT NUC, everything as usual. 
This doesn't interfere with server only scenario.

![server_bootloader](https://user-images.githubusercontent.com/77073326/186102652-f02f2cfd-904f-483b-8b81-7b9ce2a52dc5.png)

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [X] Manually tested on hardware (if hardware specific or related).

## Documentation

- [X] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
