### PR TITLE
Fixing bimanual motor reset

### DIFF
--- a/advanced/sr_gui_motor_resetter/src/sr_gui_motor_resetter/motor_resetter.py
+++ b/advanced/sr_gui_motor_resetter/src/sr_gui_motor_resetter/motor_resetter.py
@@ -4,7 +4,7 @@
 # inheriting from QObject
 #
 
-# Copyright 2011, 2022 Shadow Robot Company Ltd.
+# Copyright 2011-2023 Shadow Robot Company Ltd.
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the Free

--- a/advanced/sr_gui_motor_resetter/src/sr_gui_motor_resetter/motor_resetter.py
+++ b/advanced/sr_gui_motor_resetter/src/sr_gui_motor_resetter/motor_resetter.py
@@ -41,24 +41,24 @@ class MotorFlasher(QThread):
     motor_finished = QtCore.pyqtSignal('QPoint')
     failed = QtCore.pyqtSignal('QString')
 
-    def __init__(self, parent, nb_motors_to_program, prefix):
+    def __init__(self, parent, nb_motors_to_program, prefix, system_prefix="sr_hand_robot"):
         QThread.__init__(self, None)
         self.parent = parent
         self.nb_motors_to_program = nb_motors_to_program
         self.prefix = prefix
+        self.system_prefix = system_prefix
         self.flasher_service = None
 
     def run(self):
         programmed_motors = 0
         for motor in self.parent.motors:
             if motor.checkbox.checkState() == Qt.Checked:
+
+                service_name = f"{self.system_prefix}/{self.prefix}reset_motor_{motor.motor_name}"
                 try:
-                    print((
-                        "resetting: sr_hand_robot/" + self.prefix +
-                        "reset_motor_" + motor.motor_name))
+                    print(f"resetting: {service_name}")
                     self.flasher_service = rospy.ServiceProxy(
-                        'sr_hand_robot/' + self.prefix + 'reset_motor_' +
-                        motor.motor_name, Empty)
+                        service_name, Empty)
                     self.flasher_service()
                 except rospy.ServiceException as exception:
                     self.failed['QString'].emit(f"Service did not process request: {exception}")
@@ -125,6 +125,15 @@ class SrGuiMotorResetter(Plugin):
         else:
             self._widget.select_prefix.setCurrentIndex(0)
             self._prefix = list(hand_parameters.mapping.values())[0] + "/"
+
+        self._hand_robot_prefix = ""
+        hand_quantity = len(self._hand_finder.get_hand_parameters().joint_prefix)
+        if hand_quantity == 2:
+            self._hand_robot_prefix = 'sr_bimanual_hands_robot'
+        elif hand_quantity == 1:
+            self._hand_robot_prefix = 'sr_hand_robot'
+        else:
+            raise ValueError('Hand Finder did not find a correct number of hands')
 
         self._widget.select_prefix.currentIndexChanged['QString'].connect(
             self.prefix_selected)
@@ -247,7 +256,7 @@ class SrGuiMotorResetter(Plugin):
         self.progress_bar.setMaximum(nb_motors_to_program)
 
         self.motor_flasher = MotorFlasher(self, nb_motors_to_program,
-                                          self._prefix)
+                                          self._prefix, self._hand_robot_prefix)
 
         self.motor_flasher.finished.connect(self.finished_programming_motors)
         self.motor_flasher.motor_finished['QPoint'].connect(self.one_motor_finished)


### PR DESCRIPTION
## Proposed changes

Motor reset was failing when using a bimanual system due to a missmatch of service names:
![service_name_missmatch](https://github.com/shadow-robot/sr-visualization/assets/62122095/ce373e02-1ff8-4691-b994-1f7a92935d5e)

The following changes have been tested in a unimanual right and left system and also in bimanual (right and left cases):
![unimanual_right_reset](https://github.com/shadow-robot/sr-visualization/assets/62122095/38b59aeb-e162-4f64-959d-e312f6997f3f)
![unimanual_left_motor_reset](https://github.com/shadow-robot/sr-visualization/assets/62122095/7a3835ce-cba6-40d9-b420-167e4769bb22)
![bimanual_right_motor_reset](https://github.com/shadow-robot/sr-visualization/assets/62122095/8ca01080-1100-4a3f-a726-03713ea04bac)
![bimaual_left_motor_reset](https://github.com/shadow-robot/sr-visualization/assets/62122095/6e1266c5-6fd4-4d03-a6b4-706d78062165)

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [x] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
