### PR TITLE
B#pd 38 hand calibration gui plotjuggler to server

### DIFF
--- a/advanced/sr_gui_hand_calibration/package.xml
+++ b/advanced/sr_gui_hand_calibration/package.xml
@@ -1,5 +1,5 @@
 <!--
- Copyright 2022 Shadow Robot Company Ltd.
+ Copyright 2022, 2024 Shadow Robot Company Ltd.
  This program is free software: you can redistribute it and/or modify it
  under the terms of the GNU General Public License as published by the Free
  Software Foundation version 2 of the License.

--- a/advanced/sr_gui_hand_calibration/package.xml
+++ b/advanced/sr_gui_hand_calibration/package.xml
@@ -45,7 +45,6 @@
   <run_depend>sr_robot_msgs</run_depend>
   <run_depend>sr_robot_lib</run_depend>
 
-
   <run_depend>python3-scp</run_depend>
   <run_depend>python3-paramiko</run_depend>
 

--- a/advanced/sr_gui_hand_calibration/package.xml
+++ b/advanced/sr_gui_hand_calibration/package.xml
@@ -46,6 +46,9 @@
   <run_depend>sr_robot_lib</run_depend>
 
 
+  <run_depend>python3-scp</run_depend>
+  <run_depend>python3-paramiko</run_depend>
+
   <test_depend>python3-mock</test_depend>
   <test_depend>python-pyvirtualdisplay-pip</test_depend>
   <test_depend>xvfb</test_depend>

--- a/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/hand_calibration.py
+++ b/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/hand_calibration.py
@@ -32,8 +32,6 @@ class SrHandCalibration(Plugin):
     """
 
     def __init__(self, context):
-        rospy.logerr("###############################x1")
-
         super().__init__(context)
         self.setObjectName('SrHandCalibration')
 
@@ -62,8 +60,6 @@ class SrHandCalibration(Plugin):
         self._widget.information_btn.clicked.connect(self.display_information)
 
     def get_hand_serial(self):
-        list(rosparam.get_param('/hand/mapping').keys())
-
         os.system('sr_hand_detector_node')
 
         with open('/tmp/sr_hand_detector.yaml', encoding="ASCII") as hand_file:

--- a/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/hand_calibration.py
+++ b/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/hand_calibration.py
@@ -60,6 +60,8 @@ class SrHandCalibration(Plugin):
         self._widget.information_btn.clicked.connect(self.display_information)
 
     def get_hand_serial(self):
+        list(rosparam.get_param('/hand/mapping').keys())
+
         os.system('sr_hand_detector_node')
 
         with open('/tmp/sr_hand_detector.yaml', encoding="ASCII") as hand_file:

--- a/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/hand_calibration.py
+++ b/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/hand_calibration.py
@@ -32,6 +32,8 @@ class SrHandCalibration(Plugin):
     """
 
     def __init__(self, context):
+        rospy.logerr("###############################x1")
+
         super().__init__(context)
         self.setObjectName('SrHandCalibration')
 

--- a/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
+++ b/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
@@ -195,20 +195,22 @@ class JointCalibration(QTreeWidgetItem):
         self.package_path = package_path
         self.multiplot_processes = []
         REMOTE_PLOTJUGGLER_VARIABLES = ['SERVER_IP', 'SERVER_USERNAME', 'CONTAINER_NAME']
-        self.local_plotjuggler = True
+        self._nuc_ssh_key_path = "/home/user/.ssh/reverse_ssh_id_rsa"
+        self._local_plotjuggler = True
         self._server_ip = None
         self._server_username = None
         self._container_name = None
-        rospy.loginfo("###############################")
         if any(var in os.environ for var in REMOTE_PLOTJUGGLER_VARIABLES):
             if all(var in os.environ for var in REMOTE_PLOTJUGGLER_VARIABLES):
-                self.local_plotjuggler = False
+                self._local_plotjuggler = False
                 self._server_ip = os.environ.get('SERVER_IP')
                 self._server_username = os.environ.get('SERVER_USERNAME')
                 self._container_name = os.environ.get('CONTAINER_NAME')
             else:
-                rospy.logwarn("Some but not all remote plotjuggler variables are set. This means there has been a "\
-                              "deployment error. Please contact shadow")
+                rospy.logerr("Some but not all remote plotjuggler variables are set. "\
+                             "This means there has been a deployment error. Please contact "\
+                             "software@shadowrobot.com")
+                rospy.logwarn("Defaulting to using plotjuggler locally")
 
         if not isinstance(self.joint_name, list):
             QTreeWidgetItem.__init__(
@@ -238,82 +240,76 @@ class JointCalibration(QTreeWidgetItem):
         tree_widget.addTopLevelItem(self)
         self.timer.timeout.connect(self.update_joint_pos)
 
-    def _create_ssh_client(self, server, port, user):
-        k = paramiko.RSAKey.from_private_key_file("/home/user/.ssh/reverse_ssh_id_rsa")
+    def _create_ssh_client(self):
+        try:
+            key = paramiko.RSAKey.from_private_key_file(self._nuc_ssh_key_path)
+        except FileNotFoundError as exception:
+            rospy.logerr(f"Failed to load SSH key - {exception}")
+            return
         client = paramiko.SSHClient()
         client.load_system_host_keys()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        client.connect(server, port=port, username=user, pkey=k)
+        try:
+            client.connect(self._server_ip, port=22, username=self._server_username, pkey=key)
+        except (NoValidConnectionsError, BadHostKeyException, AuthenticationException,
+                SSHException, socket.error) as exception:
+            rospy.logerr(f"Failed to SSH back to server - {exception}")
         return client
 
-    def ssh_command(self, ip, username, container_name, command):
-        k = paramiko.RSAKey.from_private_key_file("/home/user/.ssh/reverse_ssh_id_rsa")
-        client = paramiko.SSHClient()
-        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        try:
-            client.connect(self._server_ip, 22, self._server_username, pkey=k)
-            _, stdout, stderr = client.exec_command(command)
-            rospy.logwarn(f"cmdwas: {command}")
-            std_out = stdout.read()
-            if std_out:
-                rospy.logwarn(f"stdout: {std_out}")
-            std_err = stderr.read()
-            if std_err:
-                rospy.logwarn(f"stderr: {std_err}")
-            arm_serial_number = stdout.readline()
-            client.close()
-        except NoValidConnectionsError as exception:
-            ssh_exception_message = f"Failed to SSH into arm - {exception}"
-        except (BadHostKeyException, AuthenticationException, SSHException, socket.error) as exception:
-            ssh_exception_message = f"Failed to SSH into arm - {exception}"
-
-    def get_server_info(self):
-        with open('/tmp/server_username', 'r') as f:
-            server_username = f.readline().strip('\n')
-            server_containername = f.readline().strip('\n')
-        return server_username, server_containername
+    def _ssh_command(self, command):
+        client = self._create_ssh_client()
+        _, stdout, stderr = client.exec_command(command)
+        std_out = stdout.read()
+        if std_out:
+            rospy.loginfo(f"SSH command response: {std_out}")
+        std_err = stderr.read()
+        if std_err:
+            rospy.logwarn(f"SSH stderr: {std_err}")
+            rospy.logwarn(f"SSH command was: {command}")
+        client.close()
 
     def _wrap_in_docker_exec(self, command, detach=False):
         if detach:
             return f"docker exec -d {self._container_name} bash -c '{command}'"
         return f"docker exec {self._container_name} bash -c '{command}'"
 
-    def _start_remote_plotjuggler(self, command):
-        command = [x.replace("'", "\'") for x in command]
-        run_script_command = f"source /home/user/projects/shadow_robot/base/devel/setup.bash"
-        tmp_nuc_script_path = "/tmp/ssh_start_plotjuggler.sh"
-        command_str = " ".join(command)
-        command_str = f"{run_script_command} && {command_str}"
-        rospy.logerr(f"writing {command_str} to file {tmp_nuc_script_path}")
+    @staticmethod
+    def _prepend_source_ros(command):
+        return f"source /home/user/projects/shadow_robot/base/devel/setup.bash && {command}"
+
+    def _start_remote_plotjuggler(self, rosrun_command):
+        # Escape quotes
+        # rosrun_command = [x.replace("'", "\'") for x in rosrun_command]
+        tmp_script_path = "/tmp/ssh_start_plotjuggler.sh"
+        rosrun_command_str = self._prepend_source_ros(" ".join(rosrun_command))
         try:
-            with open(tmp_nuc_script_path, "w+", encoding="ASCII") as tmp_file:
-                tmp_file.write(command_str)
+            with open(tmp_script_path, "w+", encoding="ASCII") as tmp_file:
+                tmp_file.write(rosrun_command_str)
         except Exception:
-            rospy.logerr("Failed to nucssssss ation file: {}".format(tmp_nuc_script_path))
+            rospy.logerr(f"Failed to write {rosrun_command_str} to {tmp_script_path}")
             return
-        self._send_file(tmp_nuc_script_path, tmp_nuc_script_path)
-        copy_script_command = f"docker cp /tmp/ssh_start_plotjuggler.sh {self._container_name}:/tmp/ssh_start_plotjuggler.sh"
-        enable_script_command = self._wrap_in_docker_exec("sudo chmod +x /tmp/ssh_start_plotjuggler.sh")
+        self._send_file(local_path=tmp_script_path, remote_path=tmp_script_path)
+        copy_script_command = f"docker cp {tmp_script_path} {self._container_name}:{tmp_script_path}"
+        enable_script_command = self._wrap_in_docker_exec(f"sudo chmod +x {tmp_script_path}")
         run_script_command = self._wrap_in_docker_exec("cd /tmp && ./ssh_start_plotjuggler.sh", detach=True)
         for command in [copy_script_command, enable_script_command, run_script_command]:
-            self.ssh_command(self._server_ip, self._server_username, self._container_name, command)
+            self._ssh_command(command)
 
     def _send_file(self, local_path, remote_path):
-        rospy.logwarn(f"Sending file {local_path} to {remote_path}")
-        ssh_client = self._create_ssh_client(self._server_ip, 22, self._server_username)
+        rospy.loginfo(f"Sending template file {local_path} to {remote_path}")
+        ssh_client = self._create_ssh_client()
         scp = SCPClient(ssh_client.get_transport())
         scp.put(local_path, remote_path)
         ssh_client.close()
-        rospy.logwarn(f"Sent file {local_path} to {remote_path}")
 
     def _send_template(self, template):
-        self._send_file(template, '/tmp/tmp_plot.xml')
-        copy_command = f"docker cp /tmp/tmp_plot.xml {self._container_name}:/tmp/tmp_plot.xml"
-        self.ssh_command(self._server_ip, self._server_username, self._container_name, copy_command)
-        source_command = f"source /home/user/projects/shadow_robot/base/devel/setup.bash"
-        move_command = "mv /tmp/tmp_plot.xml $(rospack find sr_gui_hand_calibration)/resource/tmp_plot.xml"
-        full_command = f"docker exec {self._container_name} bash -c '{source_command} && {move_command}'"
-        self.ssh_command(self._server_ip, self._server_username, self._container_name, full_command)
+        tmp_template_path = "/tmp/tmp_plot.xml"
+        self._send_file(local_path=template, remote_path=tmp_template_path)
+        docker_cp_command = f"docker cp /tmp/tmp_plot.xml {self._container_name}:{tmp_template_path}"
+        self._ssh_command(docker_cp_command)
+        move_command = f"mv {tmp_template_path} $(rospack find sr_gui_hand_calibration)/resource/tmp_plot.xml"
+        move_command = self._prepend_source_ros(move_command)
+        self._ssh_command(self._wrap_in_docker_exec(move_command))
 
     def plot_raw_button_clicked(self):
         temporary_file_name = "{}/resource/tmp_plot.xml".format(self.package_path)
@@ -352,8 +348,6 @@ class JointCalibration(QTreeWidgetItem):
         if len(hand_serial_side_dict) > 1:
             rospy.logerr("More than one hand detected, please only connect one hand.")
             return
-        # hand_finder = HandFinder()
-        # prefix = hand_finder.get_available_prefix()
         prefix = f"{list(hand_serial_side_dict.values())[0]}_"
         if prefix == 'lh_':
             replace_list.append(['/rh/', '/lh/'])
@@ -365,7 +359,7 @@ class JointCalibration(QTreeWidgetItem):
         except Exception:
             rospy.logerr("Failed to write temportary multiplot configuration file: {}".format(temporary_file_name))
             return
-        if not self.local_plotjuggler:
+        if not self._local_plotjuggler:
             self._send_template(temporary_file_name)
             self._start_remote_plotjuggler(process)
         else:
@@ -445,8 +439,9 @@ class JointCalibration(QTreeWidgetItem):
 
     def on_close(self):
         self.timer.stop()
-        for process in self.multiplot_processes:
-            process.terminate()
+        if not self._local_plotjuggler:
+            for process in self.multiplot_processes:
+                process.terminate()
 
 
 class FingerCalibration(QTreeWidgetItem):

--- a/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
+++ b/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
@@ -217,41 +217,102 @@ class JointCalibration(QTreeWidgetItem):
         tree_widget.addTopLevelItem(self)
         self.timer.timeout.connect(self.update_joint_pos)
 
+    def ssh_command(self, ip, username, container_name, command)
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        try:
+            client.connect(ip, username=username, imeout=5.0)
+            _, stdout, _ = client.exec_command(command)
+            arm_serial_number = stdout.readline()
+            client.close()
+        except NoValidConnectionsError as exception:
+            ssh_exception_message = f"Failed to SSH into arm - {exception}"
+        except (BadHostKeyException, AuthenticationException, SSHException, socket.error) as exception:
+            ssh_exception_message = f"Failed to SSH into arm - {exception}"
+    
+    def get_server_info(self):
+        with open('/tmp/server_username', 'r') as f:
+            server_username = f.readline().strip('\n')
+            server_containername = f.readline().strip('\n')
+        return server_username, server_containername
+
+    def _start_remote_plotjuggler(self, username, container_name, command):
+        docker_command = f"docker exec -it {container_name} bash -c '{command}'"
+        make_script_command = "echo \"{docker_command}\" > /tmp/ssh_start_plotjuggler.sh"
+        copy_script_command = f"docker cp /tmp/ssh_start_plotjuggler.sh ${container_name}:/tmp/ssh_start_plotjuggler.sh"
+        enable_script_command = f"docker exec -it {container_name} bash -c 'sudo chmod +x /tmp/ssh_start_plotjuggler.sh'"
+        run_script_command = f"source /home/user/projects/shadow_robot/base/devel/setup.bash\n"
+        for command in [make_script_command, copy_script_command, enable_script_command]:
+            self.ssh_command("server", username, container_name, command)
+
+    def hand_is_local(self):
+        if self.get_hand_serial:
+            return True
+        return False
+
+    def get_this_containers_name(self):
+        with open("/proc/self/cgroup", "r") as f:
+            container_id = f.readline().strip('\n').split('/')[-1][:12]
+        ros_master = os.environ['ROS_MASTER_URI'].strip('http://').split(':')[0]
+        
+        hand_is_local = False
+        if 'localhost' in ros_master:
+            hand_is_local = True
+        with open('/etc/hosts', 'r') as f:
+            hosts = f.readlines()
+        # for host in hosts:
+
+        with open('/tmp/server_username', 'r') as f:
+            server_username = f.readline().strip('\n')
+            server_containername = f.readline().strip('\n')
+        subprocess.run(['ls', '-l'], stdout=subprocess.PIPE).stdout.decode('utf-8')
+        return container_id
+
     def plot_raw_button_clicked(self):
         temporary_file_name = "{}/resource/tmp_plot.xml".format(self.package_path)
-        if not isinstance(self.joint_name, list):
-            if not isinstance(self.raw_value_index, list):
-                # Single joint, single sensor
-                template_filename = "{}/resource/plotjuggler_1_sensor.xml".format(self.package_path)
-                replace_list = [['sensor_id_0', str(self.raw_value_index)],
-                                ['sensor_name_0', self.joint_name]]
-                process = ["rosrun", "plotjuggler", "plotjuggler", "-n", "-l", temporary_file_name]
-            else:
-                # Single joint, two sensors
-                template_filename = "{}/resource/plotjuggler_2_sensors.xml".format(self.package_path)
-                sensor_names = self.robot_lib.get_compound_names(self.joint_name)
-                replace_list = []
-                for i, sensor_index in enumerate(self.raw_value_index):
-                    replace_list.append(["sensor_id_{}".format(i), str(sensor_index)])
-                    replace_list.append(["sensor_name_{}".format(i), sensor_names[i]])
-                process = ["rosrun", "plotjuggler", "plotjuggler", "-n", "-l", temporary_file_name]
+        if self.hand_is_local():
+            server_username, server_containername = self.get_server_info()
+            command = "rosrun plotjuggler plotjuggler"
+            self._start_remote_plotjuggler(server_username, server_containername, command)
         else:
-            # Two coupled joints, each with a single sensor
-            template_filename = "{}/resource/plotjuggler_2_sensors.xml".format(self.package_path)
-            replace_list = []
-            for i, joint_name in enumerate(self.joint_name):
-                replace_list.append(["sensor_id_{}".format(i), str(self.raw_value_index[i])])
-                replace_list.append(["sensor_name_{}".format(i), joint_name])
-                process = ["rosrun", "plotjuggler", "plotjuggler", "-n", "-l", temporary_file_name]
+            if not isinstance(self.joint_name, list):
+                if not isinstance(self.raw_value_index, list):
+                    # Single joint, single sensor
+                    template_filename = "{}/resource/plotjuggler_1_sensor.xml".format(self.package_path)
+                    replace_list = [['sensor_id_0', str(self.raw_value_index)],
+                                    ['sensor_name_0', self.joint_name]]
+                    process = ["rosrun", "plotjuggler", "plotjuggler", "-n", "-l", temporary_file_name]
+                else:
+                    # Single joint, two sensors
+                    template_filename = "{}/resource/plotjuggler_2_sensors.xml".format(self.package_path)
+                    sensor_names = self.robot_lib.get_compound_names(self.joint_name)
+                    replace_list = []
+                    for i, sensor_index in enumerate(self.raw_value_index):
+                        replace_list.append(["sensor_id_{}".format(i), str(sensor_index)])
+                        replace_list.append(["sensor_name_{}".format(i), sensor_names[i]])
+                    process = ["rosrun", "plotjuggler", "plotjuggler", "-n", "-l", temporary_file_name]
+            else:
+                # Two coupled joints, each with a single sensor
+                template_filename = "{}/resource/plotjuggler_2_sensors.xml".format(self.package_path)
+                replace_list = []
+                for i, joint_name in enumerate(self.joint_name):
+                    replace_list.append(["sensor_id_{}".format(i), str(self.raw_value_index[i])])
+                    replace_list.append(["sensor_name_{}".format(i), joint_name])
+                    process = ["rosrun", "plotjuggler", "plotjuggler", "-n", "-l", temporary_file_name]
         try:
             with open(template_filename, "r", encoding="ASCII") as template_file:
                 template = template_file.read()
         except Exception:
             rospy.logerr("Failed to open multiplot template file: {}".format(template_filename))
             return
-
-        hand_finder = HandFinder()
-        prefix = hand_finder.get_available_prefix()
+        
+        hand_serial_side_dict = rosparam.get_param('/hand/mapping')
+        if len(hand_serial_side_dict) > 1:
+            rospy.logerr("More than one hand detected, please only connect one hand.")
+            return
+        # hand_finder = HandFinder()
+        # prefix = hand_finder.get_available_prefix()
+        prefix = f"{list(hand_serial_side_dict.values())[0]}_"
         if prefix == 'lh_':
             replace_list.append(['/rh/', '/lh/'])
         for replacement in replace_list:

--- a/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
+++ b/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
@@ -239,17 +239,19 @@ class JointCalibration(QTreeWidgetItem):
         self.timer.timeout.connect(self.update_joint_pos)
 
     def _create_ssh_client(self, server, port, user):
+        k = paramiko.RSAKey.from_private_key_file("/home/user/.ssh/reverse_ssh_id_rsa")
         client = paramiko.SSHClient()
         client.load_system_host_keys()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        client.connect(server, port, user, "password")
+        client.connect(server, port=port, username=user, pkey=k)
         return client
 
     def ssh_command(self, ip, username, container_name, command):
+        k = paramiko.RSAKey.from_private_key_file("/home/user/.ssh/reverse_ssh_id_rsa")
         client = paramiko.SSHClient()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         try:
-            client.connect(self._server_ip, 22, self._server_username, "password")
+            client.connect(self._server_ip, 22, self._server_username, pkey=k)
             _, stdout, stderr = client.exec_command(command)
             rospy.logwarn(f"cmdwas: {command}")
             std_out = stdout.read()

--- a/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
+++ b/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
@@ -266,14 +266,16 @@ class JointCalibration(QTreeWidgetItem):
             ssh_exception_message = f"Failed to SSH into arm - {exception}"
         except (BadHostKeyException, AuthenticationException, SSHException, socket.error) as exception:
             ssh_exception_message = f"Failed to SSH into arm - {exception}"
-    
+
     def get_server_info(self):
         with open('/tmp/server_username', 'r') as f:
             server_username = f.readline().strip('\n')
             server_containername = f.readline().strip('\n')
         return server_username, server_containername
-    
-    def _wrap_in_docker_exec(self, command):
+
+    def _wrap_in_docker_exec(self, command, detach=False):
+        if detach:
+            return f"docker exec -d {self._container_name} bash -c '{command}'"
         return f"docker exec {self._container_name} bash -c '{command}'"
 
     def _start_remote_plotjuggler(self, command):
@@ -292,7 +294,7 @@ class JointCalibration(QTreeWidgetItem):
         self._send_file(tmp_nuc_script_path, tmp_nuc_script_path)
         copy_script_command = f"docker cp /tmp/ssh_start_plotjuggler.sh {self._container_name}:/tmp/ssh_start_plotjuggler.sh"
         enable_script_command = self._wrap_in_docker_exec("sudo chmod +x /tmp/ssh_start_plotjuggler.sh")
-        run_script_command = self._wrap_in_docker_exec("cd /tmp && ./ssh_start_plotjuggler.sh")
+        run_script_command = self._wrap_in_docker_exec("cd /tmp && ./ssh_start_plotjuggler.sh", detach=True)
         for command in [copy_script_command, enable_script_command, run_script_command]:
             self.ssh_command(self._server_ip, self._server_username, self._container_name, command)
 

--- a/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
+++ b/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
@@ -278,8 +278,6 @@ class JointCalibration(QTreeWidgetItem):
         return f"source /home/user/projects/shadow_robot/base/devel/setup.bash && {command}"
 
     def _start_remote_plotjuggler(self, rosrun_command):
-        # Escape quotes
-        # rosrun_command = [x.replace("'", "\'") for x in rosrun_command]
         tmp_script_path = "/tmp/ssh_start_plotjuggler.sh"
         rosrun_command_str = self._prepend_source_ros(" ".join(rosrun_command))
         try:

--- a/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
+++ b/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
@@ -19,16 +19,15 @@ from collections import deque
 from datetime import date
 import os
 import subprocess
+import socket
 import yaml
 import rospy
 import rospkg
-from sr_utilities.hand_finder import HandFinder
 from sr_robot_lib.etherCAT_hand_lib import EtherCAT_Hand_Lib
 from PyQt5.QtGui import QColor, QIcon
 from PyQt5.QtWidgets import QTreeWidgetItem, QTreeWidgetItemIterator, QMessageBox, QPushButton
 from PyQt5.QtCore import QTimer
 import paramiko
-import socket
 from paramiko.ssh_exception import BadHostKeyException, AuthenticationException, SSHException, NoValidConnectionsError
 import rosparam
 from scp import SCPClient
@@ -194,14 +193,14 @@ class JointCalibration(QTreeWidgetItem):
         self.plot_button.clicked.connect(self.plot_raw_button_clicked)
         self.package_path = package_path
         self.multiplot_processes = []
-        REMOTE_PLOTJUGGLER_VARIABLES = ['SERVER_IP', 'SERVER_USERNAME', 'CONTAINER_NAME']
+        remote_plotjuggler_variables = ['SERVER_IP', 'SERVER_USERNAME', 'CONTAINER_NAME']
         self._nuc_ssh_key_path = "/home/user/.ssh/reverse_ssh_id_rsa"
         self._local_plotjuggler = True
         self._server_ip = None
         self._server_username = None
         self._container_name = None
-        if any(var in os.environ for var in REMOTE_PLOTJUGGLER_VARIABLES):
-            if all(var in os.environ for var in REMOTE_PLOTJUGGLER_VARIABLES):
+        if any(var in os.environ for var in remote_plotjuggler_variables):
+            if all(var in os.environ for var in remote_plotjuggler_variables):
                 self._local_plotjuggler = False
                 self._server_ip = os.environ.get('SERVER_IP')
                 self._server_username = os.environ.get('SERVER_USERNAME')
@@ -245,7 +244,6 @@ class JointCalibration(QTreeWidgetItem):
             key = paramiko.RSAKey.from_private_key_file(self._nuc_ssh_key_path)
         except FileNotFoundError as exception:
             rospy.logerr(f"Failed to load SSH key - {exception}")
-            return
         client = paramiko.SSHClient()
         client.load_system_host_keys()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -341,7 +339,7 @@ class JointCalibration(QTreeWidgetItem):
         except Exception:
             rospy.logerr("Failed to open multiplot template file: {}".format(template_filename))
             return
-        
+
         hand_serial_side_dict = rosparam.get_param('/hand/mapping')
         if len(hand_serial_side_dict) > 1:
             rospy.logerr("More than one hand detected, please only connect one hand.")

--- a/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
+++ b/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
@@ -27,6 +27,9 @@ from sr_robot_lib.etherCAT_hand_lib import EtherCAT_Hand_Lib
 from PyQt5.QtGui import QColor, QIcon
 from PyQt5.QtWidgets import QTreeWidgetItem, QTreeWidgetItemIterator, QMessageBox, QPushButton
 from PyQt5.QtCore import QTimer
+import paramiko
+import socket
+from paramiko.ssh_exception import BadHostKeyException, AuthenticationException, SSHException, NoValidConnectionsError
 
 string_template = f"""# Copyright {date.today().year} Shadow Robot Company Ltd.
 #
@@ -193,6 +196,7 @@ class JointCalibration(QTreeWidgetItem):
         self._server_ip = None
         self._server_username = None
         self._container_name = None
+        rospy.loginfo("###############################")
         if all(var in os.environ for var in REMOTE_PLOTJUGGLER_VARIABLES):
             if any(var in os.environ for var in REMOTE_PLOTJUGGLER_VARIABLES):
                 rospy.logwarn("Some but not all remote plotjuggler variables are set. This means there has been a "\
@@ -230,11 +234,11 @@ class JointCalibration(QTreeWidgetItem):
         tree_widget.addTopLevelItem(self)
         self.timer.timeout.connect(self.update_joint_pos)
 
-    def ssh_command(self, ip, username, container_name, command)
+    def ssh_command(self, ip, username, container_name, command):
         client = paramiko.SSHClient()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         try:
-            client.connect(ip, username=username, imeout=5.0)
+            client.connect(ip, username=username, timeout=5.0)
             _, stdout, _ = client.exec_command(command)
             arm_serial_number = stdout.readline()
             client.close()

--- a/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
+++ b/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
@@ -188,6 +188,19 @@ class JointCalibration(QTreeWidgetItem):
         self.plot_button.clicked.connect(self.plot_raw_button_clicked)
         self.package_path = package_path
         self.multiplot_processes = []
+        REMOTE_PLOTJUGGLER_VARIABLES = ['SERVER_IP', 'SERVER_USERNAME', 'CONTAINER_NAME']
+        self.local_plotjuggler = True
+        self._server_ip = None
+        self._server_username = None
+        self._container_name = None
+        if all(var in os.environ for var in REMOTE_PLOTJUGGLER_VARIABLES):
+            if any(var in os.environ for var in REMOTE_PLOTJUGGLER_VARIABLES):
+                rospy.logwarn("Some but not all remote plotjuggler variables are set. This means there has been a "\
+                              "deployment error. Please contact shadow")
+            self.local_plotjuggler = False
+            self._server_ip = os.environ.get('SERVER_IP')
+            self._server_username = os.environ.get('SERVER_USERNAME')
+            self._container_name = os.environ.get('CONTAINER_NAME')
 
         if not isinstance(self.joint_name, list):
             QTreeWidgetItem.__init__(
@@ -236,14 +249,16 @@ class JointCalibration(QTreeWidgetItem):
             server_containername = f.readline().strip('\n')
         return server_username, server_containername
 
-    def _start_remote_plotjuggler(self, username, container_name, command):
-        docker_command = f"docker exec -it {container_name} bash -c '{command}'"
-        make_script_command = "echo \"{docker_command}\" > /tmp/ssh_start_plotjuggler.sh"
-        copy_script_command = f"docker cp /tmp/ssh_start_plotjuggler.sh ${container_name}:/tmp/ssh_start_plotjuggler.sh"
-        enable_script_command = f"docker exec -it {container_name} bash -c 'sudo chmod +x /tmp/ssh_start_plotjuggler.sh'"
+    def _start_remote_plotjuggler(self):
+        command = "rosrun plotjuggler plotjuggler"
+        docker_command = f"docker exec -it {self._container_name} bash -c '{command}'"
+        make_script_command = f"echo \"{docker_command}\" > /tmp/ssh_start_plotjuggler.sh"
+        copy_script_command = f"docker cp /tmp/ssh_start_plotjuggler.sh ${self._container_name}:/tmp/ssh_start_plotjuggler.sh"
+        enable_script_command = f"docker exec -it {self._container_name} bash -c 'sudo chmod +x /tmp/ssh_start_plotjuggler.sh'"
         run_script_command = f"source /home/user/projects/shadow_robot/base/devel/setup.bash\n"
+        run_script_command = f"{run_script_command}cd /tmp && ./ssh_start_plotjuggler.sh\n"
         for command in [make_script_command, copy_script_command, enable_script_command]:
-            self.ssh_command("server", username, container_name, command)
+            self.ssh_command(self._server_ip, self._server_username, self._container_name, command)
 
     def hand_is_local(self):
         if self.get_hand_serial:
@@ -270,10 +285,8 @@ class JointCalibration(QTreeWidgetItem):
 
     def plot_raw_button_clicked(self):
         temporary_file_name = "{}/resource/tmp_plot.xml".format(self.package_path)
-        if self.hand_is_local():
-            server_username, server_containername = self.get_server_info()
-            command = "rosrun plotjuggler plotjuggler"
-            self._start_remote_plotjuggler(server_username, server_containername, command)
+        if not self.local_plotjuggler:
+            self._start_remote_plotjuggler()
         else:
             if not isinstance(self.joint_name, list):
                 if not isinstance(self.raw_value_index, list):

--- a/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
+++ b/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
@@ -30,6 +30,9 @@ from PyQt5.QtCore import QTimer
 import paramiko
 import socket
 from paramiko.ssh_exception import BadHostKeyException, AuthenticationException, SSHException, NoValidConnectionsError
+import rosparam
+from scp import SCPClient
+
 
 string_template = f"""# Copyright {date.today().year} Shadow Robot Company Ltd.
 #
@@ -197,14 +200,15 @@ class JointCalibration(QTreeWidgetItem):
         self._server_username = None
         self._container_name = None
         rospy.loginfo("###############################")
-        if all(var in os.environ for var in REMOTE_PLOTJUGGLER_VARIABLES):
-            if any(var in os.environ for var in REMOTE_PLOTJUGGLER_VARIABLES):
+        if any(var in os.environ for var in REMOTE_PLOTJUGGLER_VARIABLES):
+            if all(var in os.environ for var in REMOTE_PLOTJUGGLER_VARIABLES):
+                self.local_plotjuggler = False
+                self._server_ip = os.environ.get('SERVER_IP')
+                self._server_username = os.environ.get('SERVER_USERNAME')
+                self._container_name = os.environ.get('CONTAINER_NAME')
+            else:
                 rospy.logwarn("Some but not all remote plotjuggler variables are set. This means there has been a "\
                               "deployment error. Please contact shadow")
-            self.local_plotjuggler = False
-            self._server_ip = os.environ.get('SERVER_IP')
-            self._server_username = os.environ.get('SERVER_USERNAME')
-            self._container_name = os.environ.get('CONTAINER_NAME')
 
         if not isinstance(self.joint_name, list):
             QTreeWidgetItem.__init__(
@@ -234,12 +238,26 @@ class JointCalibration(QTreeWidgetItem):
         tree_widget.addTopLevelItem(self)
         self.timer.timeout.connect(self.update_joint_pos)
 
+    def _create_ssh_client(self, server, port, user):
+        client = paramiko.SSHClient()
+        client.load_system_host_keys()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        client.connect(server, port, user, "password")
+        return client
+
     def ssh_command(self, ip, username, container_name, command):
         client = paramiko.SSHClient()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         try:
-            client.connect(ip, username=username, timeout=5.0)
-            _, stdout, _ = client.exec_command(command)
+            client.connect(self._server_ip, 22, self._server_username, "password")
+            _, stdout, stderr = client.exec_command(command)
+            rospy.logwarn(f"cmdwas: {command}")
+            std_out = stdout.read()
+            if std_out:
+                rospy.logwarn(f"stdout: {std_out}")
+            std_err = stderr.read()
+            if std_err:
+                rospy.logwarn(f"stderr: {std_err}")
             arm_serial_number = stdout.readline()
             client.close()
         except NoValidConnectionsError as exception:
@@ -252,70 +270,73 @@ class JointCalibration(QTreeWidgetItem):
             server_username = f.readline().strip('\n')
             server_containername = f.readline().strip('\n')
         return server_username, server_containername
+    
+    def _wrap_in_docker_exec(self, command):
+        return f"docker exec {self._container_name} bash -c '{command}'"
 
-    def _start_remote_plotjuggler(self):
-        command = "rosrun plotjuggler plotjuggler"
-        docker_command = f"docker exec -it {self._container_name} bash -c '{command}'"
-        make_script_command = f"echo \"{docker_command}\" > /tmp/ssh_start_plotjuggler.sh"
-        copy_script_command = f"docker cp /tmp/ssh_start_plotjuggler.sh ${self._container_name}:/tmp/ssh_start_plotjuggler.sh"
-        enable_script_command = f"docker exec -it {self._container_name} bash -c 'sudo chmod +x /tmp/ssh_start_plotjuggler.sh'"
-        run_script_command = f"source /home/user/projects/shadow_robot/base/devel/setup.bash\n"
-        run_script_command = f"{run_script_command}cd /tmp && ./ssh_start_plotjuggler.sh\n"
-        for command in [make_script_command, copy_script_command, enable_script_command]:
+    def _start_remote_plotjuggler(self, command):
+        command = [x.replace("'", "\'") for x in command]
+        run_script_command = f"source /home/user/projects/shadow_robot/base/devel/setup.bash"
+        tmp_nuc_script_path = "/tmp/ssh_start_plotjuggler.sh"
+        command_str = " ".join(command)
+        command_str = f"{run_script_command} && {command_str}"
+        rospy.logerr(f"writing {command_str} to file {tmp_nuc_script_path}")
+        try:
+            with open(tmp_nuc_script_path, "w+", encoding="ASCII") as tmp_file:
+                tmp_file.write(command_str)
+        except Exception:
+            rospy.logerr("Failed to nucssssss ation file: {}".format(tmp_nuc_script_path))
+            return
+        self._send_file(tmp_nuc_script_path, tmp_nuc_script_path)
+        copy_script_command = f"docker cp /tmp/ssh_start_plotjuggler.sh {self._container_name}:/tmp/ssh_start_plotjuggler.sh"
+        enable_script_command = self._wrap_in_docker_exec("sudo chmod +x /tmp/ssh_start_plotjuggler.sh")
+        run_script_command = self._wrap_in_docker_exec("cd /tmp && ./ssh_start_plotjuggler.sh")
+        for command in [copy_script_command, enable_script_command, run_script_command]:
             self.ssh_command(self._server_ip, self._server_username, self._container_name, command)
 
-    def hand_is_local(self):
-        if self.get_hand_serial:
-            return True
-        return False
+    def _send_file(self, local_path, remote_path):
+        rospy.logwarn(f"Sending file {local_path} to {remote_path}")
+        ssh_client = self._create_ssh_client(self._server_ip, 22, self._server_username)
+        scp = SCPClient(ssh_client.get_transport())
+        scp.put(local_path, remote_path)
+        ssh_client.close()
+        rospy.logwarn(f"Sent file {local_path} to {remote_path}")
 
-    def get_this_containers_name(self):
-        with open("/proc/self/cgroup", "r") as f:
-            container_id = f.readline().strip('\n').split('/')[-1][:12]
-        ros_master = os.environ['ROS_MASTER_URI'].strip('http://').split(':')[0]
-        
-        hand_is_local = False
-        if 'localhost' in ros_master:
-            hand_is_local = True
-        with open('/etc/hosts', 'r') as f:
-            hosts = f.readlines()
-        # for host in hosts:
-
-        with open('/tmp/server_username', 'r') as f:
-            server_username = f.readline().strip('\n')
-            server_containername = f.readline().strip('\n')
-        subprocess.run(['ls', '-l'], stdout=subprocess.PIPE).stdout.decode('utf-8')
-        return container_id
+    def _send_template(self, template):
+        self._send_file(template, '/tmp/tmp_plot.xml')
+        copy_command = f"docker cp /tmp/tmp_plot.xml {self._container_name}:/tmp/tmp_plot.xml"
+        self.ssh_command(self._server_ip, self._server_username, self._container_name, copy_command)
+        source_command = f"source /home/user/projects/shadow_robot/base/devel/setup.bash"
+        move_command = "mv /tmp/tmp_plot.xml $(rospack find sr_gui_hand_calibration)/resource/tmp_plot.xml"
+        full_command = f"docker exec {self._container_name} bash -c '{source_command} && {move_command}'"
+        self.ssh_command(self._server_ip, self._server_username, self._container_name, full_command)
 
     def plot_raw_button_clicked(self):
         temporary_file_name = "{}/resource/tmp_plot.xml".format(self.package_path)
-        if not self.local_plotjuggler:
-            self._start_remote_plotjuggler()
-        else:
-            if not isinstance(self.joint_name, list):
-                if not isinstance(self.raw_value_index, list):
-                    # Single joint, single sensor
-                    template_filename = "{}/resource/plotjuggler_1_sensor.xml".format(self.package_path)
-                    replace_list = [['sensor_id_0', str(self.raw_value_index)],
-                                    ['sensor_name_0', self.joint_name]]
-                    process = ["rosrun", "plotjuggler", "plotjuggler", "-n", "-l", temporary_file_name]
-                else:
-                    # Single joint, two sensors
-                    template_filename = "{}/resource/plotjuggler_2_sensors.xml".format(self.package_path)
-                    sensor_names = self.robot_lib.get_compound_names(self.joint_name)
-                    replace_list = []
-                    for i, sensor_index in enumerate(self.raw_value_index):
-                        replace_list.append(["sensor_id_{}".format(i), str(sensor_index)])
-                        replace_list.append(["sensor_name_{}".format(i), sensor_names[i]])
-                    process = ["rosrun", "plotjuggler", "plotjuggler", "-n", "-l", temporary_file_name]
+        if not isinstance(self.joint_name, list):
+            if not isinstance(self.raw_value_index, list):
+                # Single joint, single sensor
+                template_filename = "{}/resource/plotjuggler_1_sensor.xml".format(self.package_path)
+                replace_list = [['sensor_id_0', str(self.raw_value_index)],
+                                ['sensor_name_0', self.joint_name]]
+                process = ["rosrun", "plotjuggler", "plotjuggler", "-n", "-l", temporary_file_name]
             else:
-                # Two coupled joints, each with a single sensor
+                # Single joint, two sensors
                 template_filename = "{}/resource/plotjuggler_2_sensors.xml".format(self.package_path)
+                sensor_names = self.robot_lib.get_compound_names(self.joint_name)
                 replace_list = []
-                for i, joint_name in enumerate(self.joint_name):
-                    replace_list.append(["sensor_id_{}".format(i), str(self.raw_value_index[i])])
-                    replace_list.append(["sensor_name_{}".format(i), joint_name])
-                    process = ["rosrun", "plotjuggler", "plotjuggler", "-n", "-l", temporary_file_name]
+                for i, sensor_index in enumerate(self.raw_value_index):
+                    replace_list.append(["sensor_id_{}".format(i), str(sensor_index)])
+                    replace_list.append(["sensor_name_{}".format(i), sensor_names[i]])
+                process = ["rosrun", "plotjuggler", "plotjuggler", "-n", "-l", temporary_file_name]
+        else:
+            # Two coupled joints, each with a single sensor
+            template_filename = "{}/resource/plotjuggler_2_sensors.xml".format(self.package_path)
+            replace_list = []
+            for i, joint_name in enumerate(self.joint_name):
+                replace_list.append(["sensor_id_{}".format(i), str(self.raw_value_index[i])])
+                replace_list.append(["sensor_name_{}".format(i), joint_name])
+                process = ["rosrun", "plotjuggler", "plotjuggler", "-n", "-l", temporary_file_name]
         try:
             with open(template_filename, "r", encoding="ASCII") as template_file:
                 template = template_file.read()
@@ -340,7 +361,11 @@ class JointCalibration(QTreeWidgetItem):
         except Exception:
             rospy.logerr("Failed to write temportary multiplot configuration file: {}".format(temporary_file_name))
             return
-        self.multiplot_processes.append(subprocess.Popen(process))  # pylint: disable=R1732
+        if not self.local_plotjuggler:
+            self._send_template(temporary_file_name)
+            self._start_remote_plotjuggler(process)
+        else:
+            self.multiplot_processes.append(subprocess.Popen(process))  # pylint: disable=R1732
 
     def load_joint_calibration(self, new_calibrations):
         for calibration in self.calibrations:

--- a/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
+++ b/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2011, 2022-2023 Shadow Robot Company Ltd.
+# Copyright 2011, 2022-2024 Shadow Robot Company Ltd.
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the Free

--- a/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
+++ b/advanced/sr_gui_hand_calibration/src/sr_gui_hand_calibration/sr_hand_calibration_model.py
@@ -206,8 +206,8 @@ class JointCalibration(QTreeWidgetItem):
                 self._server_username = os.environ.get('SERVER_USERNAME')
                 self._container_name = os.environ.get('CONTAINER_NAME')
             else:
-                rospy.logerr("Some but not all remote plotjuggler variables are set. "\
-                             "This means there has been a deployment error. Please contact "\
+                rospy.logerr("Some but not all remote plotjuggler variables are set. "
+                             "This means there has been a deployment error. Please contact "
                              "software@shadowrobot.com")
                 rospy.logwarn("Defaulting to using plotjuggler locally")
 


### PR DESCRIPTION
## Proposed changes

When using sr_gui_hand_calibration rqt gui on server&nuc/teleop, the button to plot a joint should ssh back from the nuc to the server and launch plotjuggler there.

Also sends constructed plotjuggler template from nuc to server

Breaks ability for this node to keep track of plotjuggler process and kill them when the node dies

Goes with this aurora PR: https://github.com/shadow-robot/aurora/pull/597

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [ ] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
